### PR TITLE
Adjust repo to scale-info pub interface

### DIFF
--- a/scale-decode/examples/enum_decode_as_type.rs
+++ b/scale-decode/examples/enum_decode_as_type.rs
@@ -151,5 +151,5 @@ fn make_type<T: scale_info::TypeInfo + 'static>() -> (u32, scale_info::PortableR
     let id = types.register_type(&m);
     let portable_registry: scale_info::PortableRegistry = types.into();
 
-    (id.id(), portable_registry)
+    (id.id, portable_registry)
 }

--- a/scale-decode/examples/struct_decode_as_type.rs
+++ b/scale-decode/examples/struct_decode_as_type.rs
@@ -130,5 +130,5 @@ fn make_type<T: scale_info::TypeInfo + 'static>() -> (u32, scale_info::PortableR
     let id = types.register_type(&m);
     let portable_registry: scale_info::PortableRegistry = types.into();
 
-    (id.id(), portable_registry)
+    (id.id, portable_registry)
 }

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -311,5 +311,5 @@ fn make_type<T: scale_info::TypeInfo + 'static>() -> (u32, scale_info::PortableR
     let id = types.register_type(&m);
     let portable_registry: scale_info::PortableRegistry = types.into();
 
-    (id.id(), portable_registry)
+    (id.id, portable_registry)
 }

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -565,7 +565,7 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
             // a tuple or composite value. Else, fall back to default behaviour.
             // This ensures that this function strictly improves on the default
             // which would be to fail.
-            let inner_type_id = match ty.type_def() {
+            let inner_type_id = match ty.type_def {
                 scale_info::TypeDef::Composite(_) => {
                     return DecodeAsTypeResult::Skipped(self);
                 }
@@ -698,7 +698,7 @@ mod test {
         let id = types.register_type(&m);
         let portable_registry: scale_info::PortableRegistry = types.into();
 
-        (id.id(), portable_registry)
+        (id.id, portable_registry)
     }
 
     // For most of our tests, we'll assert that whatever type we encode, we can decode back again to the given type.
@@ -756,12 +756,12 @@ mod test {
 
         let (ty, types) = make_type::<Foo>();
 
-        let new_foo = match types.resolve(ty).unwrap().type_def() {
+        let new_foo = match &types.resolve(ty).unwrap().type_def {
             scale_info::TypeDef::Composite(c) => {
-                Foo::decode_as_fields(foo_encoded_cursor, c.fields(), &types).unwrap()
+                Foo::decode_as_fields(foo_encoded_cursor, c.fields.as_slice(), &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {
-                Foo::decode_as_field_ids(foo_encoded_cursor, t.fields(), &types).unwrap()
+                Foo::decode_as_field_ids(foo_encoded_cursor, t.fields.as_slice(), &types).unwrap()
             }
             _ => {
                 panic!("Expected composite or tuple type def")

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -695,7 +695,7 @@ mod test {
         let id = types.register_type(&m);
         let portable_registry: PortableRegistry = types.into();
 
-        (id.id(), portable_registry)
+        (id.id, portable_registry)
     }
 
     /// This just tests that if we try to decode some values we've encoded using a visitor

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -70,7 +70,7 @@ impl<'scale, 'info> Composite<'scale, 'info> {
     }
     /// Return whether any of the fields are unnamed.
     pub fn has_unnamed_fields(&self) -> bool {
-        self.fields.iter().any(|f| f.name().is_none())
+        self.fields.iter().any(|f| f.name.is_none())
     }
     /// Convert the remaining fields in this Composite type into a [`super::Tuple`]. This allows them to
     /// be parsed in the same way as a tuple type, discarding name information.
@@ -80,7 +80,7 @@ impl<'scale, 'info> Composite<'scale, 'info> {
     /// Return the name of the next field to be decoded; `None` if either the field has no name,
     /// or there are no fields remaining.
     pub fn peek_name(&self) -> Option<&'info str> {
-        self.fields.get(0).and_then(|f| f.name().map(|n| &**n))
+        self.fields.get(0).and_then(|f| f.name.as_deref())
     }
     /// Decode the next field in the composite type by providing a visitor to handle it. This is more
     /// efficient than iterating over the key/value pairs if you already know how you want to decode the
@@ -97,7 +97,7 @@ impl<'scale, 'info> Composite<'scale, 'info> {
         let b = &mut &*self.item_bytes;
 
         // Decode the bytes:
-        let res = crate::visitor::decode_with_visitor(b, field.ty().id(), self.types, visitor);
+        let res = crate::visitor::decode_with_visitor(b, field.ty.id, self.types, visitor);
 
         // Update self to point to the next item, now:
         self.item_bytes = *b;
@@ -149,7 +149,7 @@ impl<'scale, 'info> CompositeField<'scale, 'info> {
     }
     /// The type ID associated with this field.
     pub fn type_id(&self) -> u32 {
-        self.field.ty().id()
+        self.field.ty.id
     }
     /// Decode this field using a visitor.
     pub fn decode_with_visitor<V: Visitor>(
@@ -158,14 +158,14 @@ impl<'scale, 'info> CompositeField<'scale, 'info> {
     ) -> Result<V::Value<'scale, 'info>, V::Error> {
         crate::visitor::decode_with_visitor(
             &mut &*self.bytes,
-            self.field.ty().id(),
+            self.field.ty.id,
             self.types,
             visitor,
         )
     }
     /// Decode this field into a specific type via [`DecodeAsType`].
     pub fn decode_as_type<T: DecodeAsType>(&self) -> Result<T, crate::Error> {
-        T::decode_as_type(&mut &*self.bytes, self.field.ty().id(), self.types)
+        T::decode_as_type(&mut &*self.bytes, self.field.ty.id, self.types)
     }
 }
 

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -160,8 +160,8 @@ impl<'info> TupleFieldIds<'info> {
     }
     fn first(&self) -> Option<u32> {
         match self {
-            TupleFieldIds::Ids(fs) => fs.get(0).map(|f| f.id()),
-            TupleFieldIds::Fields(fs) => fs.get(0).map(|f| f.ty().id()),
+            TupleFieldIds::Ids(fs) => fs.get(0).map(|f| f.id),
+            TupleFieldIds::Fields(fs) => fs.get(0).map(|f| f.ty.id),
         }
     }
     fn pop_front_unwrap(&mut self) {

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -36,13 +36,13 @@ impl<'scale, 'info> Variant<'scale, 'info> {
 
         // Does a variant exist with the index we're looking for?
         let variant = ty
-            .variants()
+            .variants
             .iter()
-            .find(|v| v.index() == index)
+            .find(|v| v.index == index)
             .ok_or_else(|| DecodeError::VariantNotFound(index, ty.clone()))?;
 
         // Allow decoding of the fields:
-        let fields = Composite::new(item_bytes, path, variant.fields(), types);
+        let fields = Composite::new(item_bytes, path, variant.fields.as_slice(), types);
 
         Ok(Variant { bytes, variant, fields })
     }
@@ -66,11 +66,11 @@ impl<'scale, 'info> Variant<'scale, 'info> {
     }
     /// The name of the variant.
     pub fn name(&self) -> &'info str {
-        self.variant.name()
+        self.variant.name.as_str()
     }
     /// The index of the variant.
     pub fn index(&self) -> u8 {
-        self.variant.index()
+        self.variant.index
     }
     /// Access the variant fields.
     pub fn fields(&mut self) -> &mut Composite<'scale, 'info> {


### PR DESCRIPTION
This PR makes the transition from utilizing scale-info getter methods to using
the structure fields directly. The former method has been deprecated recently,
causing the clippy step to fail due to excessive warnings.

// @paritytech/subxt-team