### PR TITLE
Improve DecodeAsFields trait with iterator over Fields

### DIFF
--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -345,14 +345,14 @@ fn generate_struct_impl(
                 type Error = #path_to_scale_decode::Error;
                 type Value<'scale, 'info> = #path_to_type #ty_generics;
 
-                fn visit_composite<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
+                fn visit_composite<'scale, 'info, I: #path_to_scale_decode::FieldIter<'info>>(
                     self,
                     value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     #visit_composite_body
                 }
-                fn visit_tuple<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
+                fn visit_tuple<'scale, 'info, I: #path_to_scale_decode::FieldIter<'info>>(
                     self,
                     value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -218,9 +218,9 @@ fn generate_enum_impl(
                 type Error = #path_to_scale_decode::Error;
                 type Value<'scale, 'info> = #path_to_type #ty_generics;
 
-                fn visit_variant<'scale, 'info>(
+                fn visit_variant<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
                     self,
-                    value: &mut #path_to_scale_decode::visitor::types::Variant<'scale, 'info>,
+                    value: &mut #path_to_scale_decode::visitor::types::Variant<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     #(
@@ -232,9 +232,9 @@ fn generate_enum_impl(
                     }))
                 }
                 // Allow an enum to be decoded through nested 1-field composites and tuples:
-                fn visit_composite<'scale, 'info>(
+                fn visit_composite<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
                     self,
-                    value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info>,
+                    value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info, I>,
                     _type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     if value.remaining() != 1 {
@@ -242,9 +242,9 @@ fn generate_enum_impl(
                     }
                     value.decode_item(self).unwrap()
                 }
-                fn visit_tuple<'scale, 'info>(
+                fn visit_tuple<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
                     self,
-                    value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info>,
+                    value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info, I>,
                     _type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     if value.remaining() != 1 {
@@ -345,16 +345,16 @@ fn generate_struct_impl(
                 type Error = #path_to_scale_decode::Error;
                 type Value<'scale, 'info> = #path_to_type #ty_generics;
 
-                fn visit_composite<'scale, 'info>(
+                fn visit_composite<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
                     self,
-                    value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info>,
+                    value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     #visit_composite_body
                 }
-                fn visit_tuple<'scale, 'info>(
+                fn visit_tuple<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
                     self,
-                    value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info>,
+                    value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,
                 ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                     #visit_tuple_body
@@ -362,9 +362,12 @@ fn generate_struct_impl(
             }
 
             impl #impl_generics #path_to_scale_decode::DecodeAsFields for #path_to_type #ty_generics #where_clause  {
-                fn decode_as_fields(input: &mut &[u8], fields: &[#path_to_scale_decode::PortableField], types: &#path_to_scale_decode::PortableRegistry) -> Result<Self, #path_to_scale_decode::Error> {
-                    let path = Default::default();
-                    let mut composite = #path_to_scale_decode::visitor::types::Composite::new(input, &path, fields, types);
+                fn decode_as_fields<'info, DecodeAsTypeFieldsIter>(input: &mut &[u8], fields: DecodeAsTypeFieldsIter, types: &'info #path_to_scale_decode::PortableRegistry)
+                    -> Result<Self, #path_to_scale_decode::Error>
+                where DecodeAsTypeFieldsIter: std::iter::Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone
+                {
+                    let path = #path_to_scale_decode::EMPTY_SCALE_INFO_PATH;
+                    let mut composite = #path_to_scale_decode::visitor::types::Composite::new(input, path, fields, types);
                     use #path_to_scale_decode::{ Visitor, IntoVisitor };
                     let val = <#path_to_type #ty_generics>::into_visitor().visit_composite(&mut composite, #path_to_scale_decode::visitor::TypeId(0));
 

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -218,7 +218,7 @@ fn generate_enum_impl(
                 type Error = #path_to_scale_decode::Error;
                 type Value<'scale, 'info> = #path_to_type #ty_generics;
 
-                fn visit_variant<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
+                fn visit_variant<'scale, 'info, I: #path_to_scale_decode::FieldIter<'info>>(
                     self,
                     value: &mut #path_to_scale_decode::visitor::types::Variant<'scale, 'info, I>,
                     type_id: #path_to_scale_decode::visitor::TypeId,
@@ -232,7 +232,7 @@ fn generate_enum_impl(
                     }))
                 }
                 // Allow an enum to be decoded through nested 1-field composites and tuples:
-                fn visit_composite<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
+                fn visit_composite<'scale, 'info, I: #path_to_scale_decode::FieldIter<'info>>(
                     self,
                     value: &mut #path_to_scale_decode::visitor::types::Composite<'scale, 'info, I>,
                     _type_id: #path_to_scale_decode::visitor::TypeId,
@@ -242,7 +242,7 @@ fn generate_enum_impl(
                     }
                     value.decode_item(self).unwrap()
                 }
-                fn visit_tuple<'scale, 'info, I: Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone>(
+                fn visit_tuple<'scale, 'info, I: #path_to_scale_decode::FieldIter<'info>>(
                     self,
                     value: &mut #path_to_scale_decode::visitor::types::Tuple<'scale, 'info, I>,
                     _type_id: #path_to_scale_decode::visitor::TypeId,
@@ -364,7 +364,7 @@ fn generate_struct_impl(
             impl #impl_generics #path_to_scale_decode::DecodeAsFields for #path_to_type #ty_generics #where_clause  {
                 fn decode_as_fields<'info, DecodeAsTypeFieldsIter>(input: &mut &[u8], fields: DecodeAsTypeFieldsIter, types: &'info #path_to_scale_decode::PortableRegistry)
                     -> Result<Self, #path_to_scale_decode::Error>
-                where DecodeAsTypeFieldsIter: std::iter::Iterator<Item=#path_to_scale_decode::Field<'info>> + Clone
+                where DecodeAsTypeFieldsIter: #path_to_scale_decode::FieldIter<'info>
                 {
                     let path = #path_to_scale_decode::EMPTY_SCALE_INFO_PATH;
                     let mut composite = #path_to_scale_decode::visitor::types::Composite::new(input, path, fields, types);

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -23,7 +23,7 @@ primitive-types = ["dep:primitive-types"]
 derive = ["dep:scale-decode-derive"]
 
 [dependencies]
-scale-info = { version = "2.0.0", default-features = false, features = ["bit-vec", "std"] }
+scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "std"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 thiserror = "1.0.24"
 scale-bits = { version = "0.3.0", default-features = false, features = ["scale-info"] }

--- a/scale-decode/examples/enum_decode_as_type.rs
+++ b/scale-decode/examples/enum_decode_as_type.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, Field, IntoVisitor, Visitor};
+use scale_decode::{error::ErrorKind, DecodeAsType, Error, FieldIter, IntoVisitor, Visitor};
 use std::collections::HashMap;
 
 // We have some enum Foo that we'll encode to bytes. The aim of this example is
@@ -50,7 +50,7 @@ impl Visitor for FooVisitor {
     // We have opted here to be quite flexible in what we support; we'll happily ignore fields in the input that we
     // don't care about and support unnamed to named fields. You could choose to be more strict if you prefer. We also
     // add context to any errors coming from decoding sub-types via `.map_err(|e| e.at_x(..))` calls.
-    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_variant<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut scale_decode::visitor::types::Variant<'scale, 'info, I>,
         _type_id: scale_decode::visitor::TypeId,

--- a/scale-decode/examples/enum_decode_as_type.rs
+++ b/scale-decode/examples/enum_decode_as_type.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, IntoVisitor, Visitor};
+use scale_decode::{error::ErrorKind, DecodeAsType, Error, Field, IntoVisitor, Visitor};
 use std::collections::HashMap;
 
 // We have some enum Foo that we'll encode to bytes. The aim of this example is
@@ -50,9 +50,9 @@ impl Visitor for FooVisitor {
     // We have opted here to be quite flexible in what we support; we'll happily ignore fields in the input that we
     // don't care about and support unnamed to named fields. You could choose to be more strict if you prefer. We also
     // add context to any errors coming from decoding sub-types via `.map_err(|e| e.at_x(..))` calls.
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut scale_decode::visitor::types::Variant<'scale, 'info>,
+        value: &mut scale_decode::visitor::types::Variant<'scale, 'info, I>,
         _type_id: scale_decode::visitor::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.name() == "Bar" {

--- a/scale-decode/examples/struct_decode_as_type.rs
+++ b/scale-decode/examples/struct_decode_as_type.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, IntoVisitor, Visitor};
+use scale_decode::{error::ErrorKind, DecodeAsType, Error, Field, IntoVisitor, Visitor};
 use std::collections::HashMap;
 
 // We have some struct Foo that we'll encode to bytes. The aim of this example is
@@ -50,9 +50,9 @@ impl Visitor for FooVisitor {
     // unnamed fields (matching by field index if unnamed) and add context to errors via
     // `.map_err(|e| e.at_x(..))` calls to give back more precise information about where
     // decoding failed, if it does.
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut scale_decode::visitor::types::Composite<'scale, 'info>,
+        value: &mut scale_decode::visitor::types::Composite<'scale, 'info, I>,
         type_id: scale_decode::visitor::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.has_unnamed_fields() {
@@ -77,9 +77,9 @@ impl Visitor for FooVisitor {
     }
 
     // If we like, we can also support decoding from tuples of matching lengths:
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut scale_decode::visitor::types::Tuple<'scale, 'info>,
+        value: &mut scale_decode::visitor::types::Tuple<'scale, 'info, I>,
         _type_id: scale_decode::visitor::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.remaining() != 2 {

--- a/scale-decode/examples/struct_decode_as_type.rs
+++ b/scale-decode/examples/struct_decode_as_type.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, Field, IntoVisitor, Visitor};
+use scale_decode::{error::ErrorKind, DecodeAsType, Error, FieldIter, IntoVisitor, Visitor};
 use std::collections::HashMap;
 
 // We have some struct Foo that we'll encode to bytes. The aim of this example is
@@ -50,7 +50,7 @@ impl Visitor for FooVisitor {
     // unnamed fields (matching by field index if unnamed) and add context to errors via
     // `.map_err(|e| e.at_x(..))` calls to give back more precise information about where
     // decoding failed, if it does.
-    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_composite<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut scale_decode::visitor::types::Composite<'scale, 'info, I>,
         type_id: scale_decode::visitor::TypeId,
@@ -77,7 +77,7 @@ impl Visitor for FooVisitor {
     }
 
     // If we like, we can also support decoding from tuples of matching lengths:
-    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_tuple<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut scale_decode::visitor::types::Tuple<'scale, 'info, I>,
         _type_id: scale_decode::visitor::TypeId,

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -19,7 +19,7 @@ use scale_decode::visitor::{
     types::{Array, BitSequence, Compact, Composite, Sequence, Str, Tuple, Variant},
     TypeId,
 };
-use scale_decode::Field;
+use scale_decode::FieldIter;
 
 // A custom type we'd like to decode into:
 #[derive(Debug, PartialEq)]
@@ -204,7 +204,7 @@ impl visitor::Visitor for ValueVisitor {
         }
         Ok(Value::Sequence(vals))
     }
-    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_composite<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut Composite<'scale, 'info, I>,
         _type_id: TypeId,
@@ -218,7 +218,7 @@ impl visitor::Visitor for ValueVisitor {
         }
         Ok(Value::Composite(vals))
     }
-    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_tuple<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut Tuple<'scale, 'info, I>,
         _type_id: TypeId,
@@ -237,7 +237,7 @@ impl visitor::Visitor for ValueVisitor {
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
-    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_variant<'scale, 'info, I: FieldIter<'info>>(
         self,
         value: &mut Variant<'scale, 'info, I>,
         _type_id: TypeId,

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -19,6 +19,7 @@ use scale_decode::visitor::{
     types::{Array, BitSequence, Compact, Composite, Sequence, Str, Tuple, Variant},
     TypeId,
 };
+use scale_decode::Field;
 
 // A custom type we'd like to decode into:
 #[derive(Debug, PartialEq)]
@@ -203,9 +204,9 @@ impl visitor::Visitor for ValueVisitor {
         }
         Ok(Value::Sequence(vals))
     }
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut Composite<'scale, 'info>,
+        value: &mut Composite<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
@@ -217,9 +218,9 @@ impl visitor::Visitor for ValueVisitor {
         }
         Ok(Value::Composite(vals))
     }
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut Tuple<'scale, 'info>,
+        value: &mut Tuple<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
@@ -236,9 +237,9 @@ impl visitor::Visitor for ValueVisitor {
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        value: &mut Variant<'scale, 'info>,
+        value: &mut Variant<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -185,7 +185,7 @@ where
 /// for tuple and struct types, and is automatically implemented via the [`macro@DecodeAsType`] macro.
 pub trait DecodeAsFields: Sized {
     /// Given some bytes and some fields denoting their structure, attempt to decode.
-    fn decode_as_fields<'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn decode_as_fields<'info, I: FieldIter<'info>>(
         input: &mut &[u8],
         fields: I,
         types: &'info PortableRegistry,
@@ -221,6 +221,10 @@ impl<'a> Field<'a> {
         self.id
     }
 }
+
+/// An iterator over a set of fields.
+pub trait FieldIter<'a>: Iterator<Item = Field<'a>> + Clone {}
+impl<'a, T> FieldIter<'a> for T where T: Iterator<Item = Field<'a>> + Clone {}
 
 /// This trait can be implemented on any type that has an associated [`Visitor`] responsible for decoding
 /// SCALE encoded bytes to it. If you implement this on some type and the [`Visitor`] that you return has

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -26,9 +26,8 @@ This crate exposes four traits:
 - A [`DecodeAsType`] trait which is implemented for types which implement [`IntoVisitor`], and provides a high level interface for
   decoding SCALE encoded bytes into some type with the help of a type ID and [`scale_info::PortableRegistry`].
 - A [`DecodeAsFields`] trait which when implemented on some type, describes how SCALE encoded bytes can be decoded
-  into it with the help of a slice of [`PortableField`]'s or [`PortableFieldId`]'s and type registry describing the
-  shape of the encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
-  to map to the provided slices.
+  into it with the help of an iterator of [`Field`]s and a type registry describing the shape of the encoded bytes. This is
+  generally only implemented for tuples and structs, since we need a set of fields to map to the provided slices.
 
 Implementations for many built-in types are also provided for each trait, and the [`macro@DecodeAsType`] macro can be used to
 generate the relevant impls on new struct and enum types such that they get a [`DecodeAsType`] impl.

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -18,7 +18,7 @@
 mod decode;
 pub mod types;
 
-use crate::Field;
+use crate::FieldIter;
 use scale_info::form::PortableForm;
 use types::*;
 
@@ -184,7 +184,7 @@ pub trait Visitor: Sized {
         self.visit_unexpected(Unexpected::Sequence)
     }
     /// Called when a composite value is seen in the input bytes.
-    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_composite<'scale, 'info, I: FieldIter<'info>>(
         self,
         _value: &mut Composite<'scale, 'info, I>,
         _type_id: TypeId,
@@ -192,7 +192,7 @@ pub trait Visitor: Sized {
         self.visit_unexpected(Unexpected::Composite)
     }
     /// Called when a tuple of values is seen in the input bytes.
-    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_tuple<'scale, 'info, I: FieldIter<'info>>(
         self,
         _value: &mut Tuple<'scale, 'info, I>,
         _type_id: TypeId,
@@ -208,7 +208,7 @@ pub trait Visitor: Sized {
         self.visit_unexpected(Unexpected::Str)
     }
     /// Called when a variant is seen in the input bytes.
-    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+    fn visit_variant<'scale, 'info, I: FieldIter<'info>>(
         self,
         _value: &mut Variant<'scale, 'info, I>,
         _type_id: TypeId,
@@ -618,7 +618,7 @@ mod test {
             }
             Ok(Value::Sequence(vals))
         }
-        fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+        fn visit_composite<'scale, 'info, I: FieldIter<'info>>(
             self,
             value: &mut Composite<'scale, 'info, I>,
             _type_id: TypeId,
@@ -632,7 +632,7 @@ mod test {
             }
             Ok(Value::Composite(vals))
         }
-        fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+        fn visit_tuple<'scale, 'info, I: FieldIter<'info>>(
             self,
             value: &mut Tuple<'scale, 'info, I>,
             _type_id: TypeId,
@@ -651,7 +651,7 @@ mod test {
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
-        fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+        fn visit_variant<'scale, 'info, I: FieldIter<'info>>(
             self,
             value: &mut Variant<'scale, 'info, I>,
             _type_id: TypeId,
@@ -957,7 +957,7 @@ mod test {
             type Value<'scale, 'info> = (&'scale str, &'scale str);
             type Error = DecodeError;
 
-            fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+            fn visit_tuple<'scale, 'info, I: FieldIter<'info>>(
                 self,
                 value: &mut Tuple<'scale, 'info, I>,
                 _type_id: TypeId,
@@ -1008,7 +1008,7 @@ mod test {
             type Value<'scale, 'info> = std::collections::BTreeMap<&'info str, &'scale str>;
             type Error = DecodeError;
 
-            fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
+            fn visit_composite<'scale, 'info, I: FieldIter<'info>>(
                 self,
                 value: &mut Composite<'scale, 'info, I>,
                 _type_id: TypeId,

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -18,6 +18,7 @@
 mod decode;
 pub mod types;
 
+use crate::Field;
 use scale_info::form::PortableForm;
 use types::*;
 
@@ -183,17 +184,17 @@ pub trait Visitor: Sized {
         self.visit_unexpected(Unexpected::Sequence)
     }
     /// Called when a composite value is seen in the input bytes.
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        _value: &mut Composite<'scale, 'info>,
+        _value: &mut Composite<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Composite)
     }
     /// Called when a tuple of values is seen in the input bytes.
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        _value: &mut Tuple<'scale, 'info>,
+        _value: &mut Tuple<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Tuple)
@@ -207,9 +208,9 @@ pub trait Visitor: Sized {
         self.visit_unexpected(Unexpected::Str)
     }
     /// Called when a variant is seen in the input bytes.
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
         self,
-        _value: &mut Variant<'scale, 'info>,
+        _value: &mut Variant<'scale, 'info, I>,
         _type_id: TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Variant)
@@ -617,9 +618,9 @@ mod test {
             }
             Ok(Value::Sequence(vals))
         }
-        fn visit_composite<'scale, 'info>(
+        fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
             self,
-            value: &mut Composite<'scale, 'info>,
+            value: &mut Composite<'scale, 'info, I>,
             _type_id: TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
@@ -631,9 +632,9 @@ mod test {
             }
             Ok(Value::Composite(vals))
         }
-        fn visit_tuple<'scale, 'info>(
+        fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
             self,
-            value: &mut Tuple<'scale, 'info>,
+            value: &mut Tuple<'scale, 'info, I>,
             _type_id: TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
@@ -650,9 +651,9 @@ mod test {
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
-        fn visit_variant<'scale, 'info>(
+        fn visit_variant<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
             self,
-            value: &mut Variant<'scale, 'info>,
+            value: &mut Variant<'scale, 'info, I>,
             _type_id: TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
@@ -956,9 +957,9 @@ mod test {
             type Value<'scale, 'info> = (&'scale str, &'scale str);
             type Error = DecodeError;
 
-            fn visit_tuple<'scale, 'info>(
+            fn visit_tuple<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
                 self,
-                value: &mut Tuple<'scale, 'info>,
+                value: &mut Tuple<'scale, 'info, I>,
                 _type_id: TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let fst = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
@@ -1007,9 +1008,9 @@ mod test {
             type Value<'scale, 'info> = std::collections::BTreeMap<&'info str, &'scale str>;
             type Error = DecodeError;
 
-            fn visit_composite<'scale, 'info>(
+            fn visit_composite<'scale, 'info, I: Iterator<Item = Field<'info>> + Clone>(
                 self,
-                value: &mut Composite<'scale, 'info>,
+                value: &mut Composite<'scale, 'info, I>,
                 _type_id: TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let mut vals = std::collections::BTreeMap::<&'info str, &'scale str>::new();

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
-    DecodeAsType, Field,
+    DecodeAsType, Field, FieldIter,
 };
 use scale_info::{form::PortableForm, Path, PortableRegistry};
 
@@ -30,7 +30,7 @@ pub struct Composite<'scale, 'info, I> {
 
 impl<'scale, 'info, I> Composite<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     // Used in macros, but not really expected to be used elsewhere.
     #[doc(hidden)]
@@ -116,7 +116,7 @@ where
 // Iterating returns a representation of each field in the composite type.
 impl<'scale, 'info, I> Iterator for Composite<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     type Item = Result<CompositeField<'scale, 'info>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -176,7 +176,7 @@ impl<'scale, 'info> CompositeField<'scale, 'info> {
 impl<'scale, 'info, I> crate::visitor::DecodeItemIterator<'scale, 'info>
     for Composite<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     fn decode_item<'a, V: Visitor>(
         &mut self,

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -15,35 +15,38 @@
 
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
-    DecodeAsType,
+    DecodeAsType, Field,
 };
-use scale_info::{form::PortableForm, Field, Path, PortableRegistry};
+use scale_info::{form::PortableForm, Path, PortableRegistry};
 
 /// This represents a composite type.
-pub struct Composite<'scale, 'info> {
+pub struct Composite<'scale, 'info, I> {
     bytes: &'scale [u8],
     item_bytes: &'scale [u8],
     path: &'info Path<PortableForm>,
-    fields: &'info [Field<PortableForm>],
+    fields: I,
     types: &'info PortableRegistry,
 }
 
-impl<'scale, 'info> Composite<'scale, 'info> {
+impl<'scale, 'info, I> Composite<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     // Used in macros, but not really expected to be used elsewhere.
     #[doc(hidden)]
     pub fn new(
         bytes: &'scale [u8],
         path: &'info Path<PortableForm>,
-        fields: &'info [Field<PortableForm>],
+        fields: I,
         types: &'info PortableRegistry,
-    ) -> Composite<'scale, 'info> {
+    ) -> Composite<'scale, 'info, I> {
         Composite { bytes, path, item_bytes: bytes, fields, types }
     }
     /// Skip over all bytes associated with this composite type. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this composite type.
     pub fn skip_decoding(&mut self) -> Result<(), DecodeError> {
-        while !self.fields.is_empty() {
-            self.decode_item(IgnoreVisitor).transpose()?;
+        while let Some(field) = self.fields.next() {
+            self.decode_item_with_id(field.id(), IgnoreVisitor).transpose()?;
         }
         Ok(())
     }
@@ -58,29 +61,29 @@ impl<'scale, 'info> Composite<'scale, 'info> {
     }
     /// The number of un-decoded items remaining in this composite type.
     pub fn remaining(&self) -> usize {
-        self.fields.len()
+        self.fields.clone().count()
     }
     /// Path to this type.
     pub fn path(&self) -> &'info Path<PortableForm> {
         self.path
     }
     /// The yet-to-be-decoded fields still present in this composite type.
-    pub fn fields(&self) -> &'info [Field<PortableForm>] {
-        self.fields
+    pub fn fields(&self) -> I {
+        self.fields.clone()
     }
     /// Return whether any of the fields are unnamed.
     pub fn has_unnamed_fields(&self) -> bool {
-        self.fields.iter().any(|f| f.name.is_none())
+        self.fields.clone().any(|f| f.name().is_none())
     }
     /// Convert the remaining fields in this Composite type into a [`super::Tuple`]. This allows them to
     /// be parsed in the same way as a tuple type, discarding name information.
-    pub fn as_tuple(&self) -> super::Tuple<'scale, 'info> {
-        super::Tuple::new(self.item_bytes, self.fields, self.types)
+    pub fn as_tuple(&self) -> super::Tuple<'scale, 'info, I> {
+        super::Tuple::new(self.item_bytes, self.fields.clone(), self.types)
     }
     /// Return the name of the next field to be decoded; `None` if either the field has no name,
     /// or there are no fields remaining.
     pub fn peek_name(&self) -> Option<&'info str> {
-        self.fields.get(0).and_then(|f| f.name.as_deref())
+        self.fields.clone().next().and_then(|f| f.name())
     }
     /// Decode the next field in the composite type by providing a visitor to handle it. This is more
     /// efficient than iterating over the key/value pairs if you already know how you want to decode the
@@ -89,35 +92,42 @@ impl<'scale, 'info> Composite<'scale, 'info> {
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
-        if self.fields.is_empty() {
-            return None;
-        }
+        let field = self.fields.next()?;
+        self.decode_item_with_id(field.id(), visitor)
+    }
 
-        let field = &self.fields[0];
+    fn decode_item_with_id<V: Visitor>(
+        &mut self,
+        id: u32,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
         let b = &mut &*self.item_bytes;
 
         // Decode the bytes:
-        let res = crate::visitor::decode_with_visitor(b, field.ty.id, self.types, visitor);
+        let res = crate::visitor::decode_with_visitor(b, id, self.types, visitor);
 
-        // Update self to point to the next item, now:
+        // Move our bytes cursor forwards:
         self.item_bytes = *b;
-        self.fields = &self.fields[1..];
 
         Some(res)
     }
 }
 
 // Iterating returns a representation of each field in the composite type.
-impl<'scale, 'info> Iterator for Composite<'scale, 'info> {
+impl<'scale, 'info, I> Iterator for Composite<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     type Item = Result<CompositeField<'scale, 'info>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
+        let field = self.fields.next()?;
+
         // Record details we need before we decode and skip over the thing:
-        let field = self.fields.get(0)?;
-        let name = self.peek_name();
         let num_bytes_before = self.item_bytes.len();
         let item_bytes = self.item_bytes;
 
-        if let Err(e) = self.decode_item(IgnoreVisitor)? {
+        // Now, skip over the item we're going to hand back:
+        if let Err(e) = self.decode_item_with_id(field.id(), IgnoreVisitor)? {
             return Some(Err(e));
         };
 
@@ -125,23 +135,22 @@ impl<'scale, 'info> Iterator for Composite<'scale, 'info> {
         let num_bytes_after = self.item_bytes.len();
         let res_bytes = &item_bytes[..num_bytes_before - num_bytes_after];
 
-        Some(Ok(CompositeField { bytes: res_bytes, field, name, types: self.types }))
+        Some(Ok(CompositeField { bytes: res_bytes, field, types: self.types }))
     }
 }
 
 /// A single field in the composite type.
 #[derive(Copy, Clone)]
 pub struct CompositeField<'scale, 'info> {
-    name: Option<&'info str>,
     bytes: &'scale [u8],
-    field: &'info Field<PortableForm>,
+    field: Field<'info>,
     types: &'info PortableRegistry,
 }
 
 impl<'scale, 'info> CompositeField<'scale, 'info> {
     /// The field name.
     pub fn name(&self) -> Option<&'info str> {
-        self.name
+        self.field.name()
     }
     /// The bytes associated with this field.
     pub fn bytes(&self) -> &'scale [u8] {
@@ -149,27 +158,26 @@ impl<'scale, 'info> CompositeField<'scale, 'info> {
     }
     /// The type ID associated with this field.
     pub fn type_id(&self) -> u32 {
-        self.field.ty.id
+        self.field.id()
     }
     /// Decode this field using a visitor.
     pub fn decode_with_visitor<V: Visitor>(
         &self,
         visitor: V,
     ) -> Result<V::Value<'scale, 'info>, V::Error> {
-        crate::visitor::decode_with_visitor(
-            &mut &*self.bytes,
-            self.field.ty.id,
-            self.types,
-            visitor,
-        )
+        crate::visitor::decode_with_visitor(&mut &*self.bytes, self.field.id(), self.types, visitor)
     }
     /// Decode this field into a specific type via [`DecodeAsType`].
     pub fn decode_as_type<T: DecodeAsType>(&self) -> Result<T, crate::Error> {
-        T::decode_as_type(&mut &*self.bytes, self.field.ty.id, self.types)
+        T::decode_as_type(&mut &*self.bytes, self.field.id(), self.types)
     }
 }
 
-impl<'scale, 'info> crate::visitor::DecodeItemIterator<'scale, 'info> for Composite<'scale, 'info> {
+impl<'scale, 'info, I> crate::visitor::DecodeItemIterator<'scale, 'info>
+    for Composite<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     fn decode_item<'a, V: Visitor>(
         &mut self,
         visitor: V,

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -15,31 +15,34 @@
 
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
-    DecodeAsType,
+    DecodeAsType, Field,
 };
 use scale_info::PortableRegistry;
 
 /// This represents a tuple of values.
-pub struct Tuple<'scale, 'info> {
+pub struct Tuple<'scale, 'info, I> {
     bytes: &'scale [u8],
     item_bytes: &'scale [u8],
-    fields: TupleFieldIds<'info>,
+    fields: I,
     types: &'info PortableRegistry,
 }
 
-impl<'scale, 'info> Tuple<'scale, 'info> {
+impl<'scale, 'info, I> Tuple<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     pub(crate) fn new(
         bytes: &'scale [u8],
-        fields: impl Into<TupleFieldIds<'info>>,
+        fields: I,
         types: &'info PortableRegistry,
-    ) -> Tuple<'scale, 'info> {
-        Tuple { bytes, item_bytes: bytes, fields: fields.into(), types }
+    ) -> Tuple<'scale, 'info, I> {
+        Tuple { bytes, item_bytes: bytes, fields, types }
     }
     /// Skip over all bytes associated with this tuple. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this tuple.
     pub fn skip_decoding(&mut self) -> Result<(), DecodeError> {
-        while !self.fields.is_empty() {
-            self.decode_item(IgnoreVisitor).transpose()?;
+        while let Some(field) = self.fields.next() {
+            self.decode_item_with_id(field.id(), IgnoreVisitor).transpose()?;
         }
         Ok(())
     }
@@ -54,41 +57,49 @@ impl<'scale, 'info> Tuple<'scale, 'info> {
     }
     /// The number of un-decoded items remaining in the tuple.
     pub fn remaining(&self) -> usize {
-        self.fields.len()
+        self.fields.clone().count()
     }
     /// Decode the next item from the tuple by providing a visitor to handle it.
     pub fn decode_item<V: Visitor>(
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
-        if self.fields.is_empty() {
-            return None;
-        }
+        let field = self.fields.next()?;
+        self.decode_item_with_id(field.id(), visitor)
+    }
 
+    fn decode_item_with_id<V: Visitor>(
+        &mut self,
+        id: u32,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
         let b = &mut &*self.item_bytes;
-        let type_id = self.fields.first().expect("not empty; checked above");
 
         // Decode the bytes:
-        let res = crate::visitor::decode_with_visitor(b, type_id, self.types, visitor);
+        let res = crate::visitor::decode_with_visitor(b, id, self.types, visitor);
 
-        // Update self to point to the next item, now:
+        // Move our bytes cursor forwards:
         self.item_bytes = *b;
-        self.fields.pop_front_unwrap();
 
         Some(res)
     }
 }
 
 // Iterating returns a representation of each field in the tuple type.
-impl<'scale, 'info> Iterator for Tuple<'scale, 'info> {
+impl<'scale, 'info, I> Iterator for Tuple<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     type Item = Result<TupleField<'scale, 'info>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
+        let field = self.fields.next()?;
+
         // Record details we need before we decode and skip over the thing:
-        let type_id = self.fields.first()?;
         let num_bytes_before = self.item_bytes.len();
         let item_bytes = self.item_bytes;
 
-        if let Err(e) = self.decode_item(IgnoreVisitor)? {
+        // Now, skip over the item we're going to hand back:
+        if let Err(e) = self.decode_item_with_id(field.id(), IgnoreVisitor)? {
             return Some(Err(e));
         };
 
@@ -96,7 +107,7 @@ impl<'scale, 'info> Iterator for Tuple<'scale, 'info> {
         let num_bytes_after = self.item_bytes.len();
         let res_bytes = &item_bytes[..num_bytes_before - num_bytes_after];
 
-        Some(Ok(TupleField { bytes: res_bytes, type_id, types: self.types }))
+        Some(Ok(TupleField { bytes: res_bytes, type_id: field.id(), types: self.types }))
     }
 }
 
@@ -130,63 +141,14 @@ impl<'scale, 'info> TupleField<'scale, 'info> {
     }
 }
 
-impl<'scale, 'info> crate::visitor::DecodeItemIterator<'scale, 'info> for Tuple<'scale, 'info> {
+impl<'scale, 'info, I> crate::visitor::DecodeItemIterator<'scale, 'info> for Tuple<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     fn decode_item<'a, V: Visitor>(
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
         self.decode_item(visitor)
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum TupleFieldIds<'info> {
-    Ids(&'info [scale_info::interner::UntrackedSymbol<std::any::TypeId>]),
-    Fields(&'info [scale_info::Field<scale_info::form::PortableForm>]),
-}
-
-impl<'info> TupleFieldIds<'info> {
-    fn len(&self) -> usize {
-        match self {
-            TupleFieldIds::Ids(fs) => fs.len(),
-            TupleFieldIds::Fields(fs) => fs.len(),
-        }
-    }
-    fn is_empty(&self) -> bool {
-        match self {
-            TupleFieldIds::Ids(fs) => fs.is_empty(),
-            TupleFieldIds::Fields(fs) => fs.is_empty(),
-        }
-    }
-    fn first(&self) -> Option<u32> {
-        match self {
-            TupleFieldIds::Ids(fs) => fs.get(0).map(|f| f.id),
-            TupleFieldIds::Fields(fs) => fs.get(0).map(|f| f.ty.id),
-        }
-    }
-    fn pop_front_unwrap(&mut self) {
-        match self {
-            TupleFieldIds::Ids(fs) => {
-                *fs = &fs[1..];
-            }
-            TupleFieldIds::Fields(fs) => {
-                *fs = &fs[1..];
-            }
-        }
-    }
-}
-
-impl<'info> From<&'info [scale_info::interner::UntrackedSymbol<std::any::TypeId>]>
-    for TupleFieldIds<'info>
-{
-    fn from(fields: &'info [scale_info::interner::UntrackedSymbol<std::any::TypeId>]) -> Self {
-        TupleFieldIds::Ids(fields)
-    }
-}
-impl<'info> From<&'info [scale_info::Field<scale_info::form::PortableForm>]>
-    for TupleFieldIds<'info>
-{
-    fn from(fields: &'info [scale_info::Field<scale_info::form::PortableForm>]) -> Self {
-        TupleFieldIds::Fields(fields)
     }
 }

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
-    DecodeAsType, Field,
+    DecodeAsType, FieldIter,
 };
 use scale_info::PortableRegistry;
 
@@ -29,7 +29,7 @@ pub struct Tuple<'scale, 'info, I> {
 
 impl<'scale, 'info, I> Tuple<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     pub(crate) fn new(
         bytes: &'scale [u8],
@@ -88,7 +88,7 @@ where
 // Iterating returns a representation of each field in the tuple type.
 impl<'scale, 'info, I> Iterator for Tuple<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     type Item = Result<TupleField<'scale, 'info>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -143,7 +143,7 @@ impl<'scale, 'info> TupleField<'scale, 'info> {
 
 impl<'scale, 'info, I> crate::visitor::DecodeItemIterator<'scale, 'info> for Tuple<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     fn decode_item<'a, V: Visitor>(
         &mut self,

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -14,23 +14,25 @@
 // limitations under the License.
 
 use crate::visitor::{Composite, DecodeError};
+use crate::Field;
 use scale_info::form::PortableForm;
 use scale_info::{Path, PortableRegistry, TypeDefVariant};
 
 /// A representation of the a variant type.
-pub struct Variant<'scale, 'info> {
+pub struct Variant<'scale, 'info, I> {
     bytes: &'scale [u8],
     variant: &'info scale_info::Variant<PortableForm>,
-    fields: Composite<'scale, 'info>,
+    fields: Composite<'scale, 'info, I>,
 }
 
-impl<'scale, 'info> Variant<'scale, 'info> {
+impl<'scale, 'info, I> Variant<'scale, 'info, I> {
     pub(crate) fn new(
         bytes: &'scale [u8],
         path: &'info Path<PortableForm>,
         ty: &'info TypeDefVariant<PortableForm>,
         types: &'info PortableRegistry,
-    ) -> Result<Variant<'scale, 'info>, DecodeError> {
+    ) -> Result<Variant<'scale, 'info, impl Iterator<Item = Field<'info>> + Clone>, DecodeError>
+    {
         let index = *bytes.first().ok_or(DecodeError::NotEnoughInput)?;
         let item_bytes = &bytes[1..];
 
@@ -42,10 +44,17 @@ impl<'scale, 'info> Variant<'scale, 'info> {
             .ok_or_else(|| DecodeError::VariantNotFound(index, ty.clone()))?;
 
         // Allow decoding of the fields:
-        let fields = Composite::new(item_bytes, path, variant.fields.as_slice(), types);
+        let fields_iter = variant.fields.iter().map(|f| Field::new(f.ty.id, f.name.as_deref()));
+        let fields = Composite::new(item_bytes, path, fields_iter, types);
 
         Ok(Variant { bytes, variant, fields })
     }
+}
+
+impl<'scale, 'info, I> Variant<'scale, 'info, I>
+where
+    I: Iterator<Item = Field<'info>> + Clone,
+{
     /// Skip over all bytes associated with this variant. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this variant.
     pub fn skip_decoding(&mut self) -> Result<(), DecodeError> {
@@ -66,14 +75,14 @@ impl<'scale, 'info> Variant<'scale, 'info> {
     }
     /// The name of the variant.
     pub fn name(&self) -> &'info str {
-        self.variant.name.as_str()
+        &self.variant.name
     }
     /// The index of the variant.
     pub fn index(&self) -> u8 {
         self.variant.index
     }
     /// Access the variant fields.
-    pub fn fields(&mut self) -> &mut Composite<'scale, 'info> {
+    pub fn fields(&mut self) -> &mut Composite<'scale, 'info, I> {
         &mut self.fields
     }
 }

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::visitor::{Composite, DecodeError};
-use crate::Field;
+use crate::{Field, FieldIter};
 use scale_info::form::PortableForm;
 use scale_info::{Path, PortableRegistry, TypeDefVariant};
 
@@ -31,8 +31,7 @@ impl<'scale, 'info, I> Variant<'scale, 'info, I> {
         path: &'info Path<PortableForm>,
         ty: &'info TypeDefVariant<PortableForm>,
         types: &'info PortableRegistry,
-    ) -> Result<Variant<'scale, 'info, impl Iterator<Item = Field<'info>> + Clone>, DecodeError>
-    {
+    ) -> Result<Variant<'scale, 'info, impl FieldIter<'info>>, DecodeError> {
         let index = *bytes.first().ok_or(DecodeError::NotEnoughInput)?;
         let item_bytes = &bytes[1..];
 
@@ -53,7 +52,7 @@ impl<'scale, 'info, I> Variant<'scale, 'info, I> {
 
 impl<'scale, 'info, I> Variant<'scale, 'info, I>
 where
-    I: Iterator<Item = Field<'info>> + Clone,
+    I: FieldIter<'info>,
 {
     /// Skip over all bytes associated with this variant. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this variant.


### PR DESCRIPTION
See https://github.com/paritytech/scale-encode/pull/7

This PR makes the same change in `scale-decode` as the above for consistency.