### PR TITLE
Add no-std compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,12 @@ jobs:
           command: check
           args: --lib --bins --examples --no-default-features --workspace
 
+      - name: Check no features primitive Types
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --lib --bins --examples --no-default-features --workspace --features primitive-types
+
   wasm:
     name: Check WASM compatibility
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust
 
+name: Rust
+
 on:
   push:
     # Run jobs when commits are pushed to
@@ -23,8 +25,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -39,13 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          args: --lib --bins --examples --no-default-features --workspace
-
-      - name: Check no features primitive Types
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
-          args: --lib --bins --examples --no-default-features --workspace --features primitive-types
+          args: --all-targets --no-default-features --workspace
 
   wasm:
     name: Check WASM compatibility
@@ -54,8 +54,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -68,6 +73,33 @@ jobs:
           # we run tests using BitVec<u64,_> which doesn't.
           args: --all-features --target wasm32-unknown-unknown
 
+  no_std:
+    name: Check no_std build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      # no_std version currently needs nightly due to error_in_core feature
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: aarch64-unknown-none
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Check no_std build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          # The aarch64-unknown-none doesn't support `std`, so this
+          # will fail if the crate is not no_std compatible.
+          args: --no-default-features --target aarch64-unknown-none --features derive,primitive-types
+
   fmt:
     name: Cargo fmt
     runs-on: ubuntu-latest
@@ -75,8 +107,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            override: true
+            components: rustfmt
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -94,8 +131,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -110,8 +151,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -135,8 +180,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            components: clippy
+            override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,12 +23,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: init-rust-target
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,12 @@ jobs:
           command: check
           args: --all-targets --all-features --workspace
 
+      - name: Check no features
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --all-targets --no-default-features --workspace
+
   wasm:
     name: Check WASM compatibility
     runs-on: ubuntu-latest
@@ -72,12 +78,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      # no_std version currently needs nightly due to error_in_core feature
-      - name: Install Rust nightly toolchain
+      - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: aarch64-unknown-none
           override: true
 
@@ -90,7 +95,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args:  --lib --bins --examples --no-default-features --target aarch64-unknown-none --features primitive-types
+          args: --no-default-features --target aarch64-unknown-none --features primitive-types,derive
 
   fmt:
     name: Cargo fmt
@@ -158,6 +163,12 @@ jobs:
         with:
           command: test
           args: --all-targets --workspace
+
+      - name: Cargo test no_std
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --all-targets --workspace --no-default-features --features derive,primitive-types
 
       - name: Cargo test docs
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: init-rust-target
+      - name: Install rust toolchain
         run: rustup show
 
       - name: Rust Cache
@@ -48,13 +48,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+      - name: Install rust toolchain
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -74,13 +69,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            profile: minimal
-            toolchain: stable
-            override: true
-            components: rustfmt
+      - name: Install rust toolchain
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -98,12 +88,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+     - name: Install rust toolchain
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0
@@ -147,13 +133,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            profile: minimal
-            toolchain: stable
-            components: clippy
-            override: true
+      - name: Install rust toolchain
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,5 @@
 name: Rust
+
 on:
   push:
     # Run jobs when commits are pushed to

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,12 +41,6 @@ jobs:
           command: check
           args: --all-targets --all-features --workspace
 
-      - name: Check no features
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
-          args: --all-targets --no-default-features --workspace
-
   wasm:
     name: Check WASM compatibility
     runs-on: ubuntu-latest
@@ -98,7 +92,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: --no-default-features --target aarch64-unknown-none --features derive,primitive-types
+          args: --all-targets --no-default-features --target aarch64-unknown-none --features derive,primitive-types
 
   fmt:
     name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,4 @@
 name: Rust
-
-name: Rust
-
 on:
   push:
     # Run jobs when commits are pushed to

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-     - name: Install rust toolchain
+      - name: Install rust toolchain
         run: rustup show
 
       - name: Rust Cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          args: --all-targets --no-default-features --workspace
+          args: --lib --bins --examples --no-default-features --workspace
 
   wasm:
     name: Check WASM compatibility
@@ -104,12 +104,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install rust toolchain
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@060bda31e0be4f453bb6ed2d7e5427b31734ad01 # v2.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: --all-targets --no-default-features --target aarch64-unknown-none --features derive,primitive-types
+          args: --all-targets --no-default-features --target aarch64-unknown-none --features primitive-types
 
   fmt:
     name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: --all-targets --no-default-features --target aarch64-unknown-none --features primitive-types
+          args:  --lib --bins --examples --no-default-features --target aarch64-unknown-none --features primitive-types
 
   fmt:
     name: Cargo fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "scale-decode",
     "scale-decode-derive",
+    "testing/no_std",
 ]
 
 [workspace.package]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly-2023-05-22"
-targets = ["wasm32-unknown-unknown"]
-profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-05-22"
+targets = ["wasm32-unknown-unknown"]
+profile = "default" # include rustfmt, clippy

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -158,7 +158,7 @@ fn generate_enum_impl(
                     )*
                     Err(#path_to_scale_decode::Error::new(#path_to_scale_decode::error::ErrorKind::CannotFindVariant {
                         got: value.name().to_string(),
-                        expected: #path_to_scale_decode::vec![#(#variant_names),*]
+                        expected: vec![#(#variant_names),*]
                     }))
                 }
                 // Allow an enum to be decoded through nested 1-field composites and tuples:

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -89,7 +89,7 @@ fn generate_enum_impl(
                         let vals = fields;
                         Ok(#path_to_type::#variant_ident { #(#field_tuple_keyvals),* })
                     } else {
-                        let vals: ::alloc::collections::BTreeMap<Option<&str>, _> = fields
+                        let vals: #path_to_scale_decode::BTreeMap<Option<&str>, _> = fields
                             .map(|res| res.map(|item| (item.name(), item)))
                             .collect::<Result<_, _>>()?;
                         Ok(#path_to_type::#variant_ident { #(#field_composite_keyvals),* })
@@ -211,7 +211,7 @@ fn generate_struct_impl(
                        return self.visit_tuple(&mut value.as_tuple(), type_id)
                     }
 
-                    let vals: ::alloc::collections::BTreeMap<Option<&str>, _> =
+                    let vals: #path_to_scale_decode::BTreeMap<Option<&str>, _> =
                         value.map(|res| res.map(|item| (item.name(), item))).collect::<Result<_, _>>()?;
 
                     Ok(#path_to_type { #(#field_composite_keyvals),* })

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate alloc;
+
+use alloc::string::ToString;
 use darling::FromAttributes;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -86,7 +89,7 @@ fn generate_enum_impl(
                         let vals = fields;
                         Ok(#path_to_type::#variant_ident { #(#field_tuple_keyvals),* })
                     } else {
-                        let vals: ::std::collections::HashMap<Option<&str>, _> = fields
+                        let vals: ::alloc::collections::BTreeMap<Option<&str>, _> = fields
                             .map(|res| res.map(|item| (item.name(), item)))
                             .collect::<Result<_, _>>()?;
                         Ok(#path_to_type::#variant_ident { #(#field_composite_keyvals),* })
@@ -128,13 +131,16 @@ fn generate_enum_impl(
     quote!(
         const _: () = {
             #visibility struct Visitor #impl_generics (
-                ::std::marker::PhantomData<#phantomdata_type>
+                ::core::marker::PhantomData<#phantomdata_type>
             );
+
+            use #path_to_scale_decode::vec;
+            use #path_to_scale_decode::ToString;
 
             impl #impl_generics #path_to_scale_decode::IntoVisitor for #path_to_type #ty_generics #where_clause {
                 type Visitor = Visitor #ty_generics;
                 fn into_visitor() -> Self::Visitor {
-                    Visitor(::std::marker::PhantomData)
+                    Visitor(::core::marker::PhantomData)
                 }
             }
 
@@ -152,7 +158,7 @@ fn generate_enum_impl(
                     )*
                     Err(#path_to_scale_decode::Error::new(#path_to_scale_decode::error::ErrorKind::CannotFindVariant {
                         got: value.name().to_string(),
-                        expected: vec![#(#variant_names),*]
+                        expected: #path_to_scale_decode::vec![#(#variant_names),*]
                     }))
                 }
                 // Allow an enum to be decoded through nested 1-field composites and tuples:
@@ -205,7 +211,7 @@ fn generate_struct_impl(
                        return self.visit_tuple(&mut value.as_tuple(), type_id)
                     }
 
-                    let vals: ::std::collections::HashMap<Option<&str>, _> =
+                    let vals: ::alloc::collections::BTreeMap<Option<&str>, _> =
                         value.map(|res| res.map(|item| (item.name(), item))).collect::<Result<_, _>>()?;
 
                     Ok(#path_to_type { #(#field_composite_keyvals),* })
@@ -255,13 +261,15 @@ fn generate_struct_impl(
     quote!(
         const _: () = {
             #visibility struct Visitor #impl_generics (
-                ::std::marker::PhantomData<#phantomdata_type>
+                ::core::marker::PhantomData<#phantomdata_type>
             );
+
+
 
             impl #impl_generics #path_to_scale_decode::IntoVisitor for #path_to_type #ty_generics #where_clause {
                 type Visitor = Visitor #ty_generics;
                 fn into_visitor() -> Self::Visitor {
-                    Visitor(::std::marker::PhantomData)
+                    Visitor(::core::marker::PhantomData)
                 }
             }
 
@@ -320,8 +328,8 @@ fn named_field_keyvals<'f>(
         if skip_field {
             return (
                 false,
-                quote!(#field_ident: ::std::default::Default::default()),
-                quote!(#field_ident: ::std::default::Default::default())
+                quote!(#field_ident: ::core::default::Default::default()),
+                quote!(#field_ident: ::core::default::Default::default())
             )
         }
 
@@ -332,7 +340,7 @@ fn named_field_keyvals<'f>(
             quote!(#field_ident: {
                 let val = *vals
                     .get(&Some(#field_name))
-                    .ok_or_else(|| #path_to_scale_decode::Error::new(#path_to_scale_decode::error::ErrorKind::CannotFindField { name: #field_name.to_owned() }))?;
+                    .ok_or_else(|| #path_to_scale_decode::Error::new(#path_to_scale_decode::error::ErrorKind::CannotFindField { name: #field_name.to_string() }))?;
                 val.decode_as_type().map_err(|e| e.at_field(#field_name))?
             }),
             // For turning named fields in scale typeinfo into unnamed fields on tuple like type:
@@ -362,7 +370,7 @@ fn unnamed_field_vals<'f>(
 
         // If a field is skipped, we expect it to have a Default impl to use to populate it instead.
         if skip_field {
-            return (false, quote!(::std::default::Default::default()));
+            return (false, quote!(::core::default::Default::default()));
         }
 
         (

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -264,7 +264,8 @@ fn generate_struct_impl(
                 ::core::marker::PhantomData<#phantomdata_type>
             );
 
-
+            use #path_to_scale_decode::vec;
+            use #path_to_scale_decode::ToString;
 
             impl #impl_generics #path_to_scale_decode::IntoVisitor for #path_to_type #ty_generics #where_clause {
                 type Visitor = Visitor #ty_generics;

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -22,22 +22,21 @@ std = ["scale-info/std"]
 # Impls for primitive-types.
 primitive-types = ["dep:primitive-types"]
 
-# Enable the `DecodeAsType` macro. This is only availbale in std.
-derive = ["dep:scale-decode-derive", "std"]
+# Enable the `DecodeAsType` macro.
+derive = ["dep:scale-decode-derive"]
 
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
-derive_more = { version = "0.99.5" }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
 
 [dev-dependencies]
-scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "std", "derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
-bitvec = "1"
+scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "bit-vec"] }
+bitvec = { version = "1.0.1", default-features = false }
 trybuild = "1.0.72"
 # Enable the scale-info feature for testing.
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -29,7 +29,7 @@ derive = ["dep:scale-decode-derive"]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99.5" }
-scale-bits = { version = "0.3.0", default-features = false, features = ["scale-info"] }
+scale-bits = { default-features = false, features = ["scale-info"], git = "https://github.com/haerdib/scale-bits.git", branch = "bh/no-std" }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -16,7 +16,7 @@ include.workspace = true
 [features]
 default = ["std", "derive", "primitive-types"]
 
-# Activates std feature
+# Activates std feature.
 std = ["scale-info/std"]
 
 # Impls for primitive-types.

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -14,7 +14,10 @@ keywords.workspace = true
 include.workspace = true
 
 [features]
-default = ["derive", "primitive-types"]
+default = ["std", "derive", "primitive-types"]
+
+# Activates std feature
+std = ["scale-info/std"]
 
 # Impls for primitive-types.
 primitive-types = ["dep:primitive-types"]
@@ -23,9 +26,9 @@ primitive-types = ["dep:primitive-types"]
 derive = ["dep:scale-decode-derive"]
 
 [dependencies]
-scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "std"] }
+scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
-thiserror = "1.0.24"
+derive_more = { version = "0.99.5" }
 scale-bits = { version = "0.3.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -29,7 +29,7 @@ derive = ["dep:scale-decode-derive"]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99.5" }
-scale-bits = { default-features = false, features = ["scale-info"], git = "https://github.com/haerdib/scale-bits.git", branch = "bh/no-std" }
+scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -22,7 +22,7 @@ std = ["scale-info/std"]
 # Impls for primitive-types.
 primitive-types = ["dep:primitive-types"]
 
-# Enable the `DecodeAsType` macro.
+# Enable the `DecodeAsType` macro. This is only availbale in std.
 derive = ["dep:scale-decode-derive"]
 
 [dependencies]

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -23,7 +23,7 @@ std = ["scale-info/std"]
 primitive-types = ["dep:primitive-types"]
 
 # Enable the `DecodeAsType` macro. This is only availbale in std.
-derive = ["dep:scale-decode-derive"]
+derive = ["dep:scale-decode-derive", "std"]
 
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }

--- a/scale-decode/src/error/context.rs
+++ b/scale-decode/src/error/context.rs
@@ -16,7 +16,7 @@
 //! This module provides a [`Context`] type, which tracks the path
 //! that we're attempting to encode to aid in error reporting.
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 /// A cheaply clonable opaque context which allows us to track the current
 /// location into a type that we're trying to encode, to aid in
@@ -55,8 +55,8 @@ impl<'a> Path<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Path<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a> core::fmt::Display for Path<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for (idx, loc) in self.0.iter().enumerate() {
             if idx != 0 {
                 f.write_str(".")?;

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -23,6 +23,13 @@ use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use core::fmt::Display;
 use derive_more::From;
 
+// Error in core is currently only available as nightly feature. Therefore, we
+// differentiate here between std and no_std environments.
+#[cfg(not(feature = "std"))]
+use core::error::Error as StdError;
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+
 /// An error produced while attempting to decode some type.
 #[derive(Debug, From)]
 pub struct Error {
@@ -113,7 +120,7 @@ pub enum ErrorKind {
         /// Name of the field which was not provided.
         name: String,
     },
-    /// A custom error
+    /// A custom error.
     Custom(CustomError),
 }
 
@@ -129,7 +136,7 @@ impl From<CustomError> for ErrorKind {
     }
 }
 
-type CustomError = Box<dyn core::error::Error + Send + Sync + 'static>;
+type CustomError = Box<dyn StdError + Send + Sync + 'static>;
 
 #[cfg(test)]
 mod test {
@@ -141,7 +148,7 @@ mod test {
         Foo,
     }
 
-    impl core::error::Error for MyError {}
+    impl StdError for MyError {}
 
     #[test]
     fn custom_error() {

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -21,9 +21,10 @@ pub use context::{Context, Location};
 use crate::visitor::DecodeError;
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use core::fmt::Display;
+use derive_more::From;
 
 /// An error produced while attempting to decode some type.
-#[derive(Debug)]
+#[derive(Debug, From)]
 pub struct Error {
     context: Context,
     kind: ErrorKind,

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -45,6 +45,7 @@ use core::{
     time::Duration,
 };
 use scale_bits::Bits;
+
 pub struct BasicVisitor<T> {
     _marker: core::marker::PhantomData<T>,
 }

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -712,7 +712,7 @@ mod test {
     fn assert_encode_decode_to_with<T, A, B>(a: &A, b: &B)
     where
         A: Encode,
-        B: DecodeAsType + PartialEq + std::fmt::Debug,
+        B: DecodeAsType + PartialEq + core::fmt::Debug,
         T: scale_info::TypeInfo + 'static,
     {
         let (type_id, types) = make_type::<T>();
@@ -726,7 +726,7 @@ mod test {
     fn assert_encode_decode_to<A, B>(a: &A, b: &B)
     where
         A: Encode + scale_info::TypeInfo + 'static,
-        B: DecodeAsType + PartialEq + std::fmt::Debug,
+        B: DecodeAsType + PartialEq + core::fmt::Debug,
     {
         assert_encode_decode_to_with::<A, A, B>(a, b);
     }
@@ -734,7 +734,7 @@ mod test {
     // Most of the time we'll just make sure that we can encode and decode back to the same type.
     fn assert_encode_decode_with<T, A>(a: &A)
     where
-        A: Encode + DecodeAsType + PartialEq + std::fmt::Debug,
+        A: Encode + DecodeAsType + PartialEq + core::fmt::Debug,
         T: scale_info::TypeInfo + 'static,
     {
         assert_encode_decode_to_with::<T, A, A>(a, a)
@@ -743,7 +743,7 @@ mod test {
     // Most of the time we'll just make sure that we can encode and decode back to the same type.
     fn assert_encode_decode<A>(a: &A)
     where
-        A: Encode + scale_info::TypeInfo + 'static + DecodeAsType + PartialEq + std::fmt::Debug,
+        A: Encode + scale_info::TypeInfo + 'static + DecodeAsType + PartialEq + core::fmt::Debug,
     {
         assert_encode_decode_to(a, a)
     }
@@ -754,7 +754,7 @@ mod test {
         Foo: scale_info::TypeInfo
             + DecodeAsFields
             + PartialEq
-            + std::fmt::Debug
+            + core::fmt::Debug
             + codec::Encode
             + 'static,
     {
@@ -876,7 +876,7 @@ mod test {
                 + 'static
                 + DecodeAsType
                 + PartialEq
-                + std::fmt::Debug
+                + core::fmt::Debug
                 + Clone,
         {
             let tup = ((a.clone(),),);
@@ -1085,7 +1085,7 @@ mod test {
 
     #[test]
     fn decode_as_fields_works() {
-        use std::fmt::Debug;
+        use core::fmt::Debug;
 
         #[derive(DecodeAsType, codec::Encode, PartialEq, Debug, scale_info::TypeInfo)]
         #[decode_as_type(crate_path = "crate")]

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -24,24 +24,29 @@ use crate::{
     },
     DecodeAsFields, FieldIter, IntoVisitor,
 };
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::Rc,
+    string::{String, ToString},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
 use codec::Compact;
 use core::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
     NonZeroU32, NonZeroU64, NonZeroU8,
 };
-use scale_bits::Bits;
-use std::ops::{Range, RangeInclusive};
-use std::rc::Rc;
-use std::sync::Arc;
-use std::time::Duration;
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+use core::{
     marker::PhantomData,
+    ops::{Range, RangeInclusive},
+    time::Duration,
 };
-
+use scale_bits::Bits;
 pub struct BasicVisitor<T> {
-    _marker: std::marker::PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
 /// Generate an [`IntoVisitor`] impl for basic types `T` where `BasicVisitor<T>` impls `Visitor`.
@@ -54,7 +59,7 @@ macro_rules! impl_into_visitor {
         {
             type Visitor = BasicVisitor<$ty $(< $($lt,)* $($param),* >)?>;
             fn into_visitor() -> Self::Visitor {
-                BasicVisitor { _marker: std::marker::PhantomData }
+                BasicVisitor { _marker: core::marker::PhantomData }
             }
         }
     };
@@ -247,7 +252,7 @@ where
 {
     type Visitor = BasicVisitor<Cow<'a, T>>;
     fn into_visitor() -> Self::Visitor {
-        BasicVisitor { _marker: std::marker::PhantomData }
+        BasicVisitor { _marker: core::marker::PhantomData }
     }
 }
 
@@ -332,7 +337,7 @@ where
 {
     type Visitor = BasicVisitor<[T; N]>;
     fn into_visitor() -> Self::Visitor {
-        BasicVisitor { _marker: std::marker::PhantomData }
+        BasicVisitor { _marker: core::marker::PhantomData }
     }
 }
 
@@ -621,7 +626,7 @@ macro_rules! impl_decode_tuple {
         {
             type Visitor = BasicVisitor<($($t,)*)>;
             fn into_visitor() -> Self::Visitor {
-                BasicVisitor { _marker: std::marker::PhantomData }
+                BasicVisitor { _marker: core::marker::PhantomData }
             }
         }
 
@@ -676,7 +681,7 @@ where
     D: DecodeItemIterator<'scale, 'info>,
 {
     let mut idx = 0;
-    std::iter::from_fn(move || {
+    core::iter::from_fn(move || {
         let item = decoder
             .decode_item(T::into_visitor())
             .map(|res| res.map_err(|e| Error::from(e).at_idx(idx)));

--- a/scale-decode/src/impls/primitive_types.rs
+++ b/scale-decode/src/impls/primitive_types.rs
@@ -40,7 +40,7 @@ macro_rules! impl_visitor {
                     input,
                     type_id.0,
                     types,
-                    BasicVisitor::<[u8; $len / 8]> { _marker: std::marker::PhantomData },
+                    BasicVisitor::<[u8; $len / 8]> { _marker: core::marker::PhantomData },
                 )
                 .map(|res| <$ty>::from(res));
                 DecodeAsTypeResult::Decoded(res)
@@ -50,7 +50,7 @@ macro_rules! impl_visitor {
         impl IntoVisitor for $ty {
             type Visitor = BasicVisitor<$ty>;
             fn into_visitor() -> Self::Visitor {
-                BasicVisitor { _marker: std::marker::PhantomData }
+                BasicVisitor { _marker: core::marker::PhantomData }
             }
         }
     };

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-#![feature(error_in_core)]
+#![cfg_attr(not(feature = "std"), no_std, feature(error_in_core))]
 
 /*!
 `parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those types.

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -154,6 +154,12 @@ pub use scale_info::PortableRegistry;
 #[doc(hidden)]
 pub use alloc::{collections::BTreeMap, string::ToString, vec};
 
+/// Re-exports of external crates.
+pub mod ext {
+    #[cfg(feature = "primitive-types")]
+    pub use primitive_types;
+}
+
 use alloc::vec::Vec;
 
 /// This trait is implemented for any type `T` where `T` implements [`IntoVisitor`] and the errors returned

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std, feature(error_in_core))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 /*!
 `parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those types.
@@ -139,8 +139,6 @@ for efficient type based decoding.
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-
 mod impls;
 
 pub mod error;
@@ -151,6 +149,11 @@ pub use visitor::Visitor;
 
 // Used in trait definitions.
 pub use scale_info::PortableRegistry;
+
+pub use alloc::string::ToString;
+pub use alloc::vec;
+
+use alloc::vec::Vec;
 
 /// This trait is implemented for any type `T` where `T` implements [`IntoVisitor`] and the errors returned
 /// from this [`Visitor`] can be converted into [`Error`]. It's essentially a convenience wrapper around

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -150,6 +150,7 @@ pub use visitor::Visitor;
 // Used in trait definitions.
 pub use scale_info::PortableRegistry;
 
+pub use alloc::collections::BTreeMap;
 pub use alloc::string::ToString;
 pub use alloc::vec;
 

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -150,9 +150,9 @@ pub use visitor::Visitor;
 // Used in trait definitions.
 pub use scale_info::PortableRegistry;
 
-pub use alloc::collections::BTreeMap;
-pub use alloc::string::ToString;
-pub use alloc::vec;
+// This is exported for generated derive code to use, to be compatible with std or no-std as needed.
+#[doc(hidden)]
+pub use alloc::{collections::BTreeMap, string::ToString, vec};
 
 use alloc::vec::Vec;
 

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(error_in_core)]
+
 /*!
 `parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those types.
 This crate builds on this, and allows bytes to be decoded into types based on [`scale_info`] type information, rather than the shape
@@ -134,6 +137,10 @@ If this high level interface isn't suitable, you can implement your own [`visito
 for efficient type based decoding.
 */
 #![deny(missing_docs)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
 
 mod impls;
 

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -347,7 +347,7 @@ impl Display for DecodeError {
                 write!(f, "Cannot find type with ID {id}")
             }
             DecodeError::Unexpected(unexpected) => {
-                write!(f, "Unexpected type {0}")
+                write!(f, "Unexpected type {unexpected}")
             }
         }
     }

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -18,6 +18,7 @@
 mod decode;
 pub mod types;
 
+use core::fmt::Display;
 use scale_info::form::PortableForm;
 use types::*;
 
@@ -315,6 +316,40 @@ impl From<BitSequenceError> for DecodeError {
 impl From<alloc::str::Utf8Error> for DecodeError {
     fn from(err: alloc::str::Utf8Error) -> Self {
         Self::InvalidStr(err)
+    }
+}
+
+impl Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DecodeError::BitSequenceError(error) => {
+                write!(f, "Cannot decode bit sequence: {error:?}")
+            }
+            DecodeError::CannotDecodeCompactIntoType(portable_type) => {
+                write!(f, "Could not decode compact encoded type into {portable_type:?}")
+            }
+            DecodeError::InvalidStr(error) => {
+                write!(f, "Could not decode string: {error:?}")
+            }
+            DecodeError::InvalidChar(char) => {
+                write!(f, "{char} is expected to be a valid char, but is not")
+            }
+            DecodeError::NotEnoughInput => {
+                write!(f, "Ran out of data during decoding")
+            }
+            DecodeError::VariantNotFound(index, type_def_variant) => {
+                write!(f, "Could not find variant with index {index} in {type_def_variant:?}")
+            }
+            DecodeError::CodecError(error) => {
+                write!(f, "{error}")
+            }
+            DecodeError::TypeIdNotFound(id) => {
+                write!(f, "Cannot find type with ID {id}")
+            }
+            DecodeError::Unexpected(unexpected) => {
+                write!(f, "Unexpected type {0}")
+            }
+        }
     }
 }
 

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -984,7 +984,7 @@ mod test {
 
     #[test]
     fn zero_copy_using_info_and_scale_lifetimes() {
-        use std::collections::BTreeMap;
+        use alloc::collections::BTreeMap;
 
         #[derive(codec::Encode, scale_info::TypeInfo)]
         struct Foo {
@@ -1013,7 +1013,7 @@ mod test {
         // This zero-copy decodes a composite into map of strings:
         struct ZeroCopyMapVisitor;
         impl Visitor for ZeroCopyMapVisitor {
-            type Value<'scale, 'info> = std::collections::BTreeMap<&'info str, &'scale str>;
+            type Value<'scale, 'info> = alloc::collections::BTreeMap<&'info str, &'scale str>;
             type Error = DecodeError;
 
             fn visit_composite<'scale, 'info>(
@@ -1021,7 +1021,7 @@ mod test {
                 value: &mut Composite<'scale, 'info>,
                 _type_id: TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-                let mut vals = std::collections::BTreeMap::<&'info str, &'scale str>::new();
+                let mut vals = alloc::collections::BTreeMap::<&'info str, &'scale str>::new();
                 for item in value {
                     let item = item?;
                     let Some(key) = item.name() else { continue };
@@ -1069,7 +1069,7 @@ mod test {
 
         // We can also use this functionality to "fall-back" to a Decode impl
         // (though obviously with the caveat that this may be incorrect).
-        struct CodecDecodeVisitor<T>(std::marker::PhantomData<T>);
+        struct CodecDecodeVisitor<T>(core::marker::PhantomData<T>);
         impl<T: codec::Decode> Visitor for CodecDecodeVisitor<T> {
             type Value<'scale, 'info> = T;
             type Error = DecodeError;
@@ -1089,7 +1089,7 @@ mod test {
             &mut &*input_encoded,
             ty_id,
             &types,
-            CodecDecodeVisitor(std::marker::PhantomData),
+            CodecDecodeVisitor(core::marker::PhantomData),
         )
         .unwrap();
         assert_eq!(decoded, ("hello".to_string(), "world".to_string()));

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -419,6 +419,10 @@ mod test {
     use crate::visitor::TypeId;
 
     use super::*;
+    use alloc::borrow::ToOwned;
+    use alloc::string::{String, ToString};
+    use alloc::vec;
+    use alloc::vec::Vec;
     use codec::{self, Encode};
     use scale_info::PortableRegistry;
 

--- a/scale-decode/src/visitor/types/str.rs
+++ b/scale-decode/src/visitor/types/str.rs
@@ -56,6 +56,6 @@ impl<'scale> Str<'scale> {
     pub fn as_str(&self) -> Result<&'scale str, DecodeError> {
         let start = self.compact_len;
         let end = start + self.len;
-        std::str::from_utf8(&self.bytes[start..end]).map_err(DecodeError::InvalidStr)
+        alloc::str::from_utf8(&self.bytes[start..end]).map_err(DecodeError::InvalidStr)
     }
 }

--- a/testing/no_std/Cargo.toml
+++ b/testing/no_std/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-no-std"
+description = "Testing no_std build of scale-decode"
+readme = "README.md"
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+include.workspace = true
+
+[dependencies]
+scale-decode = { path = "../../scale-decode", default-features = false, features = ["primitive-types", "derive"] }

--- a/testing/no_std/README.md
+++ b/testing/no_std/README.md
@@ -1,0 +1,1 @@
+test no_std build of scale-decode and scale-decode-derive

--- a/testing/no_std/src/lib.rs
+++ b/testing/no_std/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+extern crate alloc;
+
+use scale_decode::DecodeAsType;
+
+pub struct NotDecodeAsType;
+
+// Enums with generic params can impl EncodeAsType.
+#[derive(DecodeAsType)]
+pub enum Bar<T, U, V> {
+    Wibble(bool, T, U, V),
+    Wobble,
+}
+
+// This impls EncodeAsType ok; we set no default trait bounds.
+#[derive(DecodeAsType)]
+#[decode_as_type(trait_bounds = "")]
+pub enum NoTraitBounds<T> {
+    Wibble(core::marker::PhantomData<T>),
+}
+
+// Structs (and const bounds) impl EncodeAsType OK.
+#[derive(DecodeAsType)]
+pub struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
+    array: [Bar; V],
+}
+
+pub fn can_decode_as_type<T: DecodeAsType>() {}

--- a/testing/no_std/src/lib.rs
+++ b/testing/no_std/src/lib.rs
@@ -22,7 +22,7 @@ pub enum NoTraitBounds<T> {
 // Structs (and const bounds) impl EncodeAsType OK.
 #[derive(DecodeAsType)]
 pub struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
-    array: [Bar; V],
+    _array: [Bar; V],
 }
 
 pub fn can_decode_as_type<T: DecodeAsType>() {}

--- a/testing/no_std/src/lib.rs
+++ b/testing/no_std/src/lib.rs
@@ -5,24 +5,25 @@ use scale_decode::DecodeAsType;
 
 pub struct NotDecodeAsType;
 
-// Enums with generic params can impl EncodeAsType.
+// Enums with generic params and even lifetimes can impl DecodeAsType.
 #[derive(DecodeAsType)]
-pub enum Bar<T, U, V> {
+pub enum Bar<'a, T, U, V> {
     Wibble(bool, T, U, V),
     Wobble,
+    Boo(alloc::borrow::Cow<'a, str>),
 }
 
-// This impls EncodeAsType ok; we set no default trait bounds.
+// This impls DecodeAsType ok; we set no default trait bounds.
 #[derive(DecodeAsType)]
 #[decode_as_type(trait_bounds = "")]
 pub enum NoTraitBounds<T> {
     Wibble(core::marker::PhantomData<T>),
 }
 
-// Structs (and const bounds) impl EncodeAsType OK.
+// Structs (and const bounds) impl DecodeAsType OK.
 #[derive(DecodeAsType)]
 pub struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
-    _array: [Bar; V],
+    pub array: [Bar; V],
 }
 
 pub fn can_decode_as_type<T: DecodeAsType>() {}


### PR DESCRIPTION
Add no-std feature gate:
- `no_std` is activated in case of deactivated `std` feature
- removes `thiserror` because it's not no-std compatible
- removes `full` feature from codec import (deprecated)

CI changes:
- Adds a `Check no_std build`
- Adds extra crate `testing/no_std` to ensure scale-encode-derive is no_std by CI

closes #25