### PR TITLE
Prep to release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## 0.8.0
 
-- Add support for `no_std` (+alloc) builds [#26](https://github.com/paritytech/scale-decode/pull/26)). Thankyou @haerdib!
+- Add support for `no_std` (+alloc) builds ([#26](https://github.com/paritytech/scale-decode/pull/26)). Thankyou @haerdib!
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.8.0
+
+- Add support for `no_std` (+alloc) builds [#26](https://github.com/paritytech/scale-decode/pull/26)). Thankyou @haerdib!
+
 ## 0.7.0
 
 - Change `DecodeAsFields` again; remove the generic iterator parameter and use `&mut dyn FieldIter` instead. This

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,5 +16,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.7.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.7.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.8.0", path = "scale-decode" }
+scale-decode-derive = { version = "0.8.0", path = "scale-decode-derive" }


### PR DESCRIPTION
- Add support for `no_std` (+alloc) builds [#26](https://github.com/paritytech/scale-decode/pull/26)). Thankyou @haerdib!