### PR TITLE
Improve error handling + consistency when no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.9.0 - 2023-07-28
+
+- Improve custom error handling: custom errors now require `Debug + Display` on `no_std` or `Error` on `std`.
+  `Error::custom()` now accepts anything implementing these traits rather than depending on `Into<Error>`.
+
 ## 0.8.0
 
 - Add support for `no_std` (+alloc) builds ([#26](https://github.com/paritytech/scale-decode/pull/26)). Thankyou @haerdib!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,5 +16,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.8.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.8.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.9.0", path = "scale-decode" }
+scale-decode-derive = { version = "0.9.0", path = "scale-decode-derive" }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -32,6 +32,7 @@ scale-bits = { version = "0.4.0", default-features = false, features = ["scale-i
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 
 [dev-dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -50,6 +50,15 @@ impl Error {
 
         Error::new(ErrorKind::Custom(Box::new(StrError(error))))
     }
+    /// Construct a custom error from an owned string.
+    pub fn custom_string(error: String) -> Error {
+        #[derive(derive_more::Display, Debug)]
+        pub struct StringError(String);
+        #[cfg(feature = "std")]
+        impl std::error::Error for StringError {}
+
+        Error::new(ErrorKind::Custom(Box::new(StringError(error))))
+    }
     /// Retrieve more information about what went wrong.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
@@ -117,7 +126,9 @@ pub enum ErrorKind {
         expected: Vec<&'static str>,
     },
     /// The types line up, but the expected length of the target type is different from the length of the input value.
-    #[display(fmt = "Cannot decode from type; expected length {expected_len} but got length {actual_len}")]
+    #[display(
+        fmt = "Cannot decode from type; expected length {expected_len} but got length {actual_len}"
+    )]
     WrongLength {
         /// Length of the type we are trying to decode from
         actual_len: usize,
@@ -140,13 +151,13 @@ pub enum ErrorKind {
 #[cfg(feature = "std")]
 pub trait CustomError: std::error::Error + Send + Sync + 'static {}
 #[cfg(feature = "std")]
-impl <T: std::error::Error + Send + Sync + 'static> CustomError for T {}
+impl<T: std::error::Error + Send + Sync + 'static> CustomError for T {}
 
 /// Anything implementing this trait can be used in [`ErrorKind::Custom`].
 #[cfg(not(feature = "std"))]
 pub trait CustomError: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static {}
 #[cfg(not(feature = "std"))]
-impl <T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
+impl<T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
 
 #[cfg(test)]
 mod test {

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -29,14 +29,26 @@ pub struct Error {
     kind: ErrorKind,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl Error {
     /// Construct a new error given an error kind.
     pub fn new(kind: ErrorKind) -> Error {
         Error { context: Context::new(), kind }
     }
     /// Construct a new, custom error.
-    pub fn custom(error: impl Into<CustomError>) -> Error {
-        Error::new(ErrorKind::Custom(error.into()))
+    pub fn custom(error: impl CustomError) -> Error {
+        Error::new(ErrorKind::Custom(Box::new(error)))
+    }
+    /// Construct a custom error from a static string.
+    pub fn custom_str(error: &'static str) -> Error {
+        #[derive(derive_more::Display, Debug)]
+        pub struct StrError(pub &'static str);
+        #[cfg(feature = "std")]
+        impl std::error::Error for StrError {}
+
+        Error::new(ErrorKind::Custom(Box::new(StrError(error))))
     }
     /// Retrieve more information about what went wrong.
     pub fn kind(&self) -> &ErrorKind {
@@ -83,17 +95,21 @@ impl From<DecodeError> for Error {
 }
 
 /// The underlying nature of the error.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum ErrorKind {
     /// Something went wrong decoding the bytes based on the type
     /// and type registry provided.
+    #[from]
+    #[display(fmt = "Error decoding bytes given the type ID and registry provided: {_0}")]
     VisitorDecodeError(DecodeError),
     /// We cannot decode the number seen into the target type; it's out of range.
+    #[display(fmt = "Number {value} is out of range")]
     NumberOutOfRange {
         /// A string representation of the numeric value that was out of range.
         value: String,
     },
     /// We cannot find the variant we're trying to decode from in the target type.
+    #[display(fmt = "Cannot find variant {got}; expects one of {expected:?}")]
     CannotFindVariant {
         /// The variant that we are given back from the encoded bytes.
         got: String,
@@ -101,6 +117,7 @@ pub enum ErrorKind {
         expected: Vec<&'static str>,
     },
     /// The types line up, but the expected length of the target type is different from the length of the input value.
+    #[display(fmt = "Cannot decode from type; expected length {expected_len} but got length {actual_len}")]
     WrongLength {
         /// Length of the type we are trying to decode from
         actual_len: usize,
@@ -108,81 +125,40 @@ pub enum ErrorKind {
         expected_len: usize,
     },
     /// Cannot find a field that we need to decode to our target type
+    #[display(fmt = "Field {name} does not exist in our encoded data")]
     CannotFindField {
         /// Name of the field which was not provided.
         name: String,
     },
     /// A custom error.
-    Custom(CustomError),
+    #[from]
+    #[display(fmt = "Custom error: {_0}")]
+    Custom(Box<dyn CustomError>),
 }
 
-impl From<DecodeError> for ErrorKind {
-    fn from(err: DecodeError) -> ErrorKind {
-        ErrorKind::VisitorDecodeError(err)
-    }
-}
-
-impl From<CustomError> for ErrorKind {
-    fn from(err: CustomError) -> ErrorKind {
-        ErrorKind::Custom(err)
-    }
-}
-
-impl Display for ErrorKind {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ErrorKind::VisitorDecodeError(decode_error) => {
-                write!(f, "Error decoding bytes given the type ID and registry provided: {decode_error:?}")
-            }
-            ErrorKind::NumberOutOfRange { value } => {
-                write!(f, "Number {value} is out of range")
-            }
-            ErrorKind::CannotFindVariant { got, expected } => {
-                write!(f, "Cannot find variant {got}; expects one of {expected:?}")
-            }
-            ErrorKind::WrongLength { actual_len, expected_len } => {
-                write!(f, "Cannot decode from type; expected length {expected_len} but got length {actual_len}")
-            }
-            ErrorKind::CannotFindField { name } => {
-                write!(f, "Field {name} does not exist in our encoded data")
-            }
-            ErrorKind::Custom(custom_error) => {
-                write!(f, "Custom error: {custom_error:?}")
-            }
-        }
-    }
-}
-
+/// Anything implementing this trait can be used in [`ErrorKind::Custom`].
 #[cfg(feature = "std")]
-type CustomError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub trait CustomError: std::error::Error + Send + Sync + 'static {}
+#[cfg(feature = "std")]
+impl <T: std::error::Error + Send + Sync + 'static> CustomError for T {}
 
+/// Anything implementing this trait can be used in [`ErrorKind::Custom`].
 #[cfg(not(feature = "std"))]
-type CustomError = Box<dyn core::fmt::Debug + Send + Sync + 'static>;
+pub trait CustomError: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static {}
+#[cfg(not(feature = "std"))]
+impl <T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    #[derive(Debug)]
+    #[derive(Debug, derive_more::Display)]
     enum MyError {
         Foo,
     }
 
-    impl Display for MyError {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "{self:?}")
-        }
-    }
-
     #[cfg(feature = "std")]
     impl std::error::Error for MyError {}
-
-    #[cfg(not(feature = "std"))]
-    impl Into<CustomError> for MyError {
-        fn into(self) -> CustomError {
-            Box::new(self)
-        }
-    }
 
     #[test]
     fn custom_error() {

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -112,7 +112,7 @@ pub enum ErrorKind {
     #[display(fmt = "Error decoding bytes given the type ID and registry provided: {_0}")]
     VisitorDecodeError(DecodeError),
     /// We cannot decode the number seen into the target type; it's out of range.
-    #[display(fmt = "Number '{value}' is out of range")]
+    #[display(fmt = "Number {value} is out of range")]
     NumberOutOfRange {
         /// A string representation of the numeric value that was out of range.
         value: String,

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -112,7 +112,7 @@ pub enum ErrorKind {
     #[display(fmt = "Error decoding bytes given the type ID and registry provided: {_0}")]
     VisitorDecodeError(DecodeError),
     /// We cannot decode the number seen into the target type; it's out of range.
-    #[display(fmt = "Number {value} is out of range")]
+    #[display(fmt = "Number '{value}' is out of range")]
     NumberOutOfRange {
         /// A string representation of the numeric value that was out of range.
         value: String,

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -289,7 +289,7 @@ pub enum DecodeError {
     CannotDecodeCompactIntoType(scale_info::Type<PortableForm>),
     /// Failure to decode bytes into a string.
     #[from]
-    #[display(fmt = "Could not decode string: '{_0}'")]
+    #[display(fmt = "Could not decode string: {_0}")]
     InvalidStr(alloc::str::Utf8Error),
     /// We could not convert the [`u32`] that we found into a valid [`char`].
     #[display(fmt = "{_0} is expected to be a valid char, but is not")]

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -289,7 +289,7 @@ pub enum DecodeError {
     CannotDecodeCompactIntoType(scale_info::Type<PortableForm>),
     /// Failure to decode bytes into a string.
     #[from]
-    #[display(fmt = "Could not decode string: {_0}")]
+    #[display(fmt = "Could not decode string: '{_0}'")]
     InvalidStr(alloc::str::Utf8Error),
     /// We could not convert the [`u32`] that we found into a valid [`char`].
     #[display(fmt = "{_0} is expected to be a valid char, but is not")]


### PR DESCRIPTION
I standardised no_std errors to be `Display + Debug`, which is closer to the "real" `std::error::Error` trait (and is what `serde` does too for `no_std`), exposed a couple of helpers to make constructing them from strings simpler (`scale-value` and `subxt` use these) and made use of `derive_more` since it's used in `scale-value` anyway, and is rather helpful.

Also bumped the version ready for a new release once this merges.

Part of a series:

- You are here: https://github.com/paritytech/scale-decode/pull/31
- https://github.com/paritytech/scale-encode/pull/13
- https://github.com/paritytech/scale-value/pull/40

Changes tested against Subxt; I'll update that next.