### PR TITLE
Hardcode error type in IntoVisitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "scale-decode-derive",
     "testing/no_std",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.9.0"

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -103,6 +103,13 @@ impl From<DecodeError> for Error {
     }
 }
 
+impl From<codec::Error> for Error {
+    fn from(err: codec::Error) -> Error {
+        let err: DecodeError = err.into();
+        Error::new(err.into())
+    }
+}
+
 /// The underlying nature of the error.
 #[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum ErrorKind {

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -350,9 +350,7 @@ impl<T: IntoVisitor> Visitor for BasicVisitor<BTreeMap<String, T>> {
                 continue;
             };
             // Decode the value now that we have a valid name.
-            let Some(val) = value.decode_item(T::into_visitor()) else {
-                break
-            };
+            let Some(val) = value.decode_item(T::into_visitor()) else { break };
             // Save to the map.
             let val = val.map_err(|e| Error::from(e).at_field(key.to_owned()))?;
             map.insert(key.to_owned(), val);

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -683,7 +683,7 @@ mod test {
     fn assert_encode_decode_to_with<T, A, B>(a: &A, b: &B)
     where
         A: Encode,
-        B: IntoVisitor + PartialEq + core::fmt::Debug,
+        B: DecodeAsType + PartialEq + core::fmt::Debug,
         T: scale_info::TypeInfo + 'static,
     {
         let (type_id, types) = make_type::<T>();
@@ -697,7 +697,7 @@ mod test {
     fn assert_encode_decode_to<A, B>(a: &A, b: &B)
     where
         A: Encode + scale_info::TypeInfo + 'static,
-        B: IntoVisitor + PartialEq + core::fmt::Debug,
+        B: DecodeAsType + PartialEq + core::fmt::Debug,
     {
         assert_encode_decode_to_with::<A, A, B>(a, b);
     }

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -263,8 +263,13 @@ pub trait FieldIter<'a>: Iterator<Item = Field<'a>> {}
 impl<'a, T> FieldIter<'a> for T where T: Iterator<Item = Field<'a>> {}
 
 /// This trait can be implemented on any type that has an associated [`Visitor`] responsible for decoding
-/// SCALE encoded bytes to it. Anything that implements this trait gets a [`DecodeAsType`] implementation
-/// for free.
+/// SCALE encoded bytes to it whose error type is [`Error`]. Anything that implements this trait gets a
+/// [`DecodeAsType`] implementation for free.
+// Dev note: This used to allow for any Error type that could be converted into `scale_decode::Error`.
+// The problem with this is that the `DecodeAsType` trait became tricky to use in some contexts, because it
+// didn't automatically imply so much. Realistically, being stricter here shouldn't matter too much; derive
+// impls all use `scale_decode::Error` anyway, and manual impls can just manually convert into the error
+// rather than rely on auto conversion, if they care about also being able to impl `DecodeAsType`.
 pub trait IntoVisitor {
     /// The visitor type used to decode SCALE encoded bytes to `Self`.
     type Visitor: for<'scale, 'info> visitor::Visitor<Value<'scale, 'info> = Self, Error = Error>;

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -326,6 +326,26 @@ pub enum DecodeAsTypeResult<V, R> {
     Decoded(R),
 }
 
+impl <V, R> DecodeAsTypeResult<V, R> {
+    /// If we have a [`DecodeAsTypeResult::Decoded`], the function provided will
+    /// map this decoded result to whatever it returns.
+    pub fn map_decoded<T, F: FnOnce(R) -> T>(self, f: F) -> DecodeAsTypeResult<V, T> {
+        match self {
+            DecodeAsTypeResult::Skipped(s) => DecodeAsTypeResult::Skipped(s),
+            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(f(r))
+        }
+    }
+
+    /// If we have a [`DecodeAsTypeResult::Skipped`], the function provided will
+    /// map this skipped value to whatever it returns.
+    pub fn map_skipped<T, F: FnOnce(V) -> T>(self, f: F) -> DecodeAsTypeResult<T, R> {
+        match self {
+            DecodeAsTypeResult::Skipped(s) => DecodeAsTypeResult::Skipped(f(s)),
+            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(r)
+        }
+    }
+}
+
 /// This is implemented for visitor related types which have a `decode_item` method,
 /// and allows you to generically talk about decoding unnamed items.
 pub trait DecodeItemIterator<'scale, 'info> {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -326,13 +326,13 @@ pub enum DecodeAsTypeResult<V, R> {
     Decoded(R),
 }
 
-impl <V, R> DecodeAsTypeResult<V, R> {
+impl<V, R> DecodeAsTypeResult<V, R> {
     /// If we have a [`DecodeAsTypeResult::Decoded`], the function provided will
     /// map this decoded result to whatever it returns.
     pub fn map_decoded<T, F: FnOnce(R) -> T>(self, f: F) -> DecodeAsTypeResult<V, T> {
         match self {
             DecodeAsTypeResult::Skipped(s) => DecodeAsTypeResult::Skipped(s),
-            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(f(r))
+            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(f(r)),
         }
     }
 
@@ -341,7 +341,7 @@ impl <V, R> DecodeAsTypeResult<V, R> {
     pub fn map_skipped<T, F: FnOnce(V) -> T>(self, f: F) -> DecodeAsTypeResult<T, R> {
         match self {
             DecodeAsTypeResult::Skipped(s) => DecodeAsTypeResult::Skipped(f(s)),
-            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(r)
+            DecodeAsTypeResult::Decoded(r) => DecodeAsTypeResult::Decoded(r),
         }
     }
 }

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -648,7 +648,7 @@ mod test {
         Ty: scale_info::TypeInfo + 'static,
         T: Encode,
         V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E>,
-        E: std::fmt::Debug,
+        E: core::fmt::Debug,
     >(
         val: T,
         expected: Value,
@@ -667,7 +667,7 @@ mod test {
     fn encode_decode_check_with_visitor<
         T: Encode + scale_info::TypeInfo + 'static,
         V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E>,
-        E: std::fmt::Debug,
+        E: core::fmt::Debug,
     >(
         val: T,
         expected: Value,


### PR DESCRIPTION
This PR hardcodes the error type, because, in a nutshell, we run into this issue in some places otherwise:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=51e845f1f73ed72b0eb9d3d29172089a

We can avoid _that_ specific issue by not having any bounds on `DecodeAsType` and instaed only bounding implementations of `DecodeAsType`, but that just means that `DecodeAsType` doesn't imply `IntoVisitor`, and so code like the following fails:

```rust
#[derive(DecodeAsType)]
#[decode_as_type(trait_bounds = "T: DecodeAsType")]
struct Foo<T> {
    val: Option<T>
}
```

This fails because for `Option<T>` to implement `DecodeAsType`, it must implement `IntoVisitor`, and it only does so if `T: IntoVisitor, T::Visitor::Error: Into<Error>`, ie we can't just use `DecodeAsType` as a trait bound.

With a hardcoded `Error` type on `IntoVisitor`, `DecodeAsType` can imply `IntoVisitor`, and the above issue goes away. I also added a `VisitorWithCrateError` adapter struct which makes any visitor whose error is convertible into `crate::Error` into a visitor returning `crate::Error`, so that it's easy to still adapt any viable visitor into something that can be used with `IntoVisitor`.