### PR TITLE
Use `scale-type-resolver` to be generic over the type resolver used

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-# main codeowner @paritytech/tools-team
-* @paritytech/tools-team
+# main codeowner @paritytech/subxt-team
+* @paritytech/subxt-team
 
 # CI
-/.github/ @paritytech/ci @paritytech/tools-team
+/.github/ @paritytech/ci @paritytech/subxt-team

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use alloc::string::ToString;
 use darling::FromAttributes;
-use proc_macro2::{TokenStream as TokenStream2, Span};
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{parse_macro_input, punctuated::Punctuated, DeriveInput};
 
@@ -410,13 +410,11 @@ fn unnamed_field_vals<'f>(
     (field_count, field_vals)
 }
 
-fn handle_generics<'a>(
-    attrs: &TopLevelAttrs,
-    generics: syn::Generics,
-) -> GenericTypes {
+fn handle_generics(attrs: &TopLevelAttrs, generics: syn::Generics) -> GenericTypes {
     let path_to_crate = &attrs.crate_path;
 
-    let type_resolver_ident = syn::Ident::new(GenericTypes::TYPE_RESOLVER_IDENT_STR, Span::call_site());
+    let type_resolver_ident =
+        syn::Ident::new(GenericTypes::TYPE_RESOLVER_IDENT_STR, Span::call_site());
 
     // Where clause to use on Visitor/IntoVisitor
     let visitor_where_clause = {
@@ -459,7 +457,8 @@ fn handle_generics<'a>(
     // generics for our Visitor/IntoVisitor; we just add the type resolver param to the list.
     let visitor_generics = {
         let mut type_generics = generics.clone();
-        let type_resolver_generic_param: syn::GenericParam = syn::parse_quote!(#type_resolver_ident: #path_to_crate::TypeResolver);
+        let type_resolver_generic_param: syn::GenericParam =
+            syn::parse_quote!(#type_resolver_ident: #path_to_crate::TypeResolver);
 
         type_generics.params.push(type_resolver_generic_param);
         type_generics
@@ -473,7 +472,7 @@ fn handle_generics<'a>(
         type_resolver_ident,
         visitor_generics,
         visitor_phantomdata_type,
-        visitor_where_clause
+        visitor_where_clause,
     }
 }
 

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -28,12 +28,12 @@ derive = ["dep:scale-decode-derive"]
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-bits = { path = "../../scale-bits", version = "0.4.0", default-features = false, features = ["scale-info"] }
+scale-bits = { path = "../../scale-bits", version = "0.5.0", default-features = false, features = ["scale-info"] } # TODO: Update to released crate when ready.
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
-scale-type-resolver = { path = "../../scale-type-resolver" }
+scale-type-resolver = "0.1"
 
 [dev-dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -28,11 +28,12 @@ derive = ["dep:scale-decode-derive"]
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"] }
+scale-bits = { path = "../../scale-bits", version = "0.4.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
+scale-type-resolver = { path = "../../scale-type-resolver" }
 
 [dev-dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -28,7 +28,7 @@ derive = ["dep:scale-decode-derive"]
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-bits = { path = "../../scale-bits", version = "0.5.0", default-features = false, features = ["scale-info"] } # TODO: Update to released crate when ready.
+scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-decode/README.md
+++ b/scale-decode/README.md
@@ -68,113 +68,113 @@ impl<R> ValueVisitor<R> {
 }
 
 impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
-    type Value<'scale, 'info> = Value;
+    type Value<'scale, 'resolver> = Value;
     type Error = visitor::DecodeError;
     type TypeResolver = R;
 
-    fn visit_bool<'scale, 'info>(
+    fn visit_bool<'scale, 'resolver>(
         self,
         value: bool,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Bool(value))
     }
-    fn visit_char<'scale, 'info>(
+    fn visit_char<'scale, 'resolver>(
         self,
         value: char,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Char(value))
     }
-    fn visit_u8<'scale, 'info>(
+    fn visit_u8<'scale, 'resolver>(
         self,
         value: u8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U8(value))
     }
-    fn visit_u16<'scale, 'info>(
+    fn visit_u16<'scale, 'resolver>(
         self,
         value: u16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U16(value))
     }
-    fn visit_u32<'scale, 'info>(
+    fn visit_u32<'scale, 'resolver>(
         self,
         value: u32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U32(value))
     }
-    fn visit_u64<'scale, 'info>(
+    fn visit_u64<'scale, 'resolver>(
         self,
         value: u64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U64(value))
     }
-    fn visit_u128<'scale, 'info>(
+    fn visit_u128<'scale, 'resolver>(
         self,
         value: u128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U128(value))
     }
-    fn visit_u256<'scale, 'info>(
+    fn visit_u256<'scale, 'resolver>(
         self,
         value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U256(*value))
     }
-    fn visit_i8<'scale, 'info>(
+    fn visit_i8<'scale, 'resolver>(
         self,
         value: i8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I8(value))
     }
-    fn visit_i16<'scale, 'info>(
+    fn visit_i16<'scale, 'resolver>(
         self,
         value: i16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I16(value))
     }
-    fn visit_i32<'scale, 'info>(
+    fn visit_i32<'scale, 'resolver>(
         self,
         value: i32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I32(value))
     }
-    fn visit_i64<'scale, 'info>(
+    fn visit_i64<'scale, 'resolver>(
         self,
         value: i64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I64(value))
     }
-    fn visit_i128<'scale, 'info>(
+    fn visit_i128<'scale, 'resolver>(
         self,
         value: i128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I128(value))
     }
-    fn visit_i256<'scale, 'info>(
+    fn visit_i256<'scale, 'resolver>(
         self,
         value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I256(*value))
     }
-    fn visit_sequence<'scale, 'info>(
+    fn visit_sequence<'scale, 'resolver>(
         self,
-        value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+        value: &mut Sequence<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -182,11 +182,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Sequence(vals))
     }
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+        value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         for item in value.by_ref() {
             let item = item?;
@@ -196,11 +196,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Composite(vals))
     }
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+        value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -208,18 +208,18 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Tuple(vals))
     }
-    fn visit_str<'scale, 'info>(
+    fn visit_str<'scale, 'resolver>(
         self,
         value: &mut Str<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+        value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         let fields = value.fields();
         for item in fields.by_ref() {
@@ -230,11 +230,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Variant(value.name().to_owned(), vals))
     }
-    fn visit_array<'scale, 'info>(
+    fn visit_array<'scale, 'resolver>(
         self,
-        value: &mut Array<'scale, 'info, Self::TypeResolver>,
+        value: &mut Array<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -242,11 +242,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Array(vals))
     }
-    fn visit_bitsequence<'scale, 'info>(
+    fn visit_bitsequence<'scale, 'resolver>(
         self,
         value: &mut BitSequence<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
     }

--- a/scale-decode/README.md
+++ b/scale-decode/README.md
@@ -21,10 +21,12 @@ generated.
 Here's an example of implementing `Visitor` to decode bytes into a custom `Value` type:
 
 ```rust
+use std::marker::PhantomData;
+use scale_decode::TypeResolver;
 use scale_decode::visitor::{
     self,
     types::{Array, BitSequence, Composite, Sequence, Str, Tuple, Variant},
-    TypeId,
+    TypeIdFor,
 };
 
 // A custom type we'd like to decode into:
@@ -54,117 +56,127 @@ enum Value {
 }
 
 // Implement the `Visitor` trait to define how to go from SCALE
-// values into this type:
-struct ValueVisitor;
-impl visitor::Visitor for ValueVisitor {
+// values into this type. Here, we are choosing to be generic over
+// how types are resolved, which is a good default choice when creating
+// a visitor unless you rely on a specific type resolver/ID type.
+struct ValueVisitor<R>(PhantomData<R>);
+
+impl<R> ValueVisitor<R> {
+    fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
     type Value<'scale, 'info> = Value;
     type Error = visitor::DecodeError;
+    type TypeResolver = R;
 
     fn visit_bool<'scale, 'info>(
         self,
         value: bool,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::Bool(value))
     }
     fn visit_char<'scale, 'info>(
         self,
         value: char,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::Char(value))
     }
     fn visit_u8<'scale, 'info>(
         self,
         value: u8,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U8(value))
     }
     fn visit_u16<'scale, 'info>(
         self,
         value: u16,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U16(value))
     }
     fn visit_u32<'scale, 'info>(
         self,
         value: u32,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U32(value))
     }
     fn visit_u64<'scale, 'info>(
         self,
         value: u64,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U64(value))
     }
     fn visit_u128<'scale, 'info>(
         self,
         value: u128,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U128(value))
     }
-    fn visit_u256<'info>(
+    fn visit_u256<'scale, 'info>(
         self,
-        value: &'_ [u8; 32],
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        value: &'scale [u8; 32],
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::U256(*value))
     }
     fn visit_i8<'scale, 'info>(
         self,
         value: i8,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I8(value))
     }
     fn visit_i16<'scale, 'info>(
         self,
         value: i16,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I16(value))
     }
     fn visit_i32<'scale, 'info>(
         self,
         value: i32,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I32(value))
     }
     fn visit_i64<'scale, 'info>(
         self,
         value: i64,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I64(value))
     }
     fn visit_i128<'scale, 'info>(
         self,
         value: i128,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I128(value))
     }
-    fn visit_i256<'info>(
+    fn visit_i256<'scale, 'info>(
         self,
-        value: &'_ [u8; 32],
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        value: &'scale [u8; 32],
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::I256(*value))
     }
     fn visit_sequence<'scale, 'info>(
         self,
-        value: &mut Sequence<'scale, 'info>,
-        _type_id: TypeId,
+        value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
@@ -172,13 +184,13 @@ impl visitor::Visitor for ValueVisitor {
     }
     fn visit_composite<'scale, 'info>(
         self,
-        value: &mut Composite<'scale, 'info>,
-        _type_id: TypeId,
+        value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
         for item in value.by_ref() {
             let item = item?;
-            let val = item.decode_with_visitor(ValueVisitor)?;
+            let val = item.decode_with_visitor(ValueVisitor::new())?;
             let name = item.name().unwrap_or("").to_owned();
             vals.push((name, val));
         }
@@ -186,11 +198,11 @@ impl visitor::Visitor for ValueVisitor {
     }
     fn visit_tuple<'scale, 'info>(
         self,
-        value: &mut Tuple<'scale, 'info>,
-        _type_id: TypeId,
+        value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
@@ -199,20 +211,20 @@ impl visitor::Visitor for ValueVisitor {
     fn visit_str<'scale, 'info>(
         self,
         value: &mut Str<'scale>,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
     fn visit_variant<'scale, 'info>(
         self,
-        value: &mut Variant<'scale, 'info>,
-        _type_id: TypeId,
+        value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
         let fields = value.fields();
         for item in fields.by_ref() {
             let item = item?;
-            let val = item.decode_with_visitor(ValueVisitor)?;
+            let val = item.decode_with_visitor(ValueVisitor::new())?;
             let name = item.name().unwrap_or("").to_owned();
             vals.push((name, val));
         }
@@ -220,11 +232,11 @@ impl visitor::Visitor for ValueVisitor {
     }
     fn visit_array<'scale, 'info>(
         self,
-        value: &mut Array<'scale, 'info>,
-        _type_id: TypeId,
+        value: &mut Array<'scale, 'info, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
@@ -233,7 +245,7 @@ impl visitor::Visitor for ValueVisitor {
     fn visit_bitsequence<'scale, 'info>(
         self,
         value: &mut BitSequence<'scale>,
-        _type_id: TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
@@ -244,7 +256,7 @@ impl visitor::Visitor for ValueVisitor {
 This can then be passed to a decode function like so:
 
 ```rust
-let value: Value = scale_decode::visitor::decode_with_visitor(scale_bytes, type_id, types, ValueVisitor)?;
+let value: Value = scale_decode::visitor::decode_with_visitor(scale_bytes, &type_id, &types, ValueVisitor::new())?;
 ```
 
 Where `scale_bytes` are the bytes you'd like to decode, `type_id` is the type stored in the `types` registry
@@ -255,9 +267,9 @@ If we were to then write an `IntoVisitor` implementation like so:
 
 ```rust
 impl scale_decode::IntoVisitor for Value {
-    type Visitor = ValueVisitor;
-    fn into_visitor() -> Self::Visitor {
-        ValueVisitor
+    type AnyVisitor<R: TypeResolver> = ValueVisitor<R>;
+    fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R> {
+        ValueVisitor::new()
     }
 }
 ```

--- a/scale-decode/examples/enum_decode_as_type.rs
+++ b/scale-decode/examples/enum_decode_as_type.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, IntoVisitor, Visitor, TypeResolver, visitor::TypeIdFor};
+use scale_decode::{
+    error::ErrorKind, visitor::TypeIdFor, DecodeAsType, Error, IntoVisitor, TypeResolver, Visitor,
+};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
@@ -32,7 +34,7 @@ enum Foo {
 // Define a struct that will be our `Visitor` capable of decoding to a `Foo`.
 struct FooVisitor<R>(PhantomData<R>);
 
-impl <R> FooVisitor<R> {
+impl<R> FooVisitor<R> {
     fn new() -> Self {
         Self(PhantomData)
     }
@@ -50,7 +52,7 @@ impl IntoVisitor for Foo {
 // any error type that can be converted into a `scale_decode::Error`), we'll also get a `DecodeAsType`
 // implementation for free (and it will compose nicely with other types that implement `DecodeAsType`).
 // We can opt not to do this if we prefer.
-impl <R: TypeResolver> Visitor for FooVisitor<R> {
+impl<R: TypeResolver> Visitor for FooVisitor<R> {
     type Value<'scale, 'info> = Foo;
     type Error = Error;
     type TypeResolver = R;
@@ -130,9 +132,13 @@ fn main() {
         Foo::decode_as_type(&mut &*empty_bytes, &type_id, &types).unwrap();
 
     // Or we can also manually use our `Visitor` impl:
-    let bar_via_visitor =
-        scale_decode::visitor::decode_with_visitor(&mut &*bar_bytes, &type_id, &types, FooVisitor::new())
-            .unwrap();
+    let bar_via_visitor = scale_decode::visitor::decode_with_visitor(
+        &mut &*bar_bytes,
+        &type_id,
+        &types,
+        FooVisitor::new(),
+    )
+    .unwrap();
     let wibble_via_visitor = scale_decode::visitor::decode_with_visitor(
         &mut &*wibble_bytes,
         &type_id,
@@ -140,9 +146,13 @@ fn main() {
         FooVisitor::new(),
     )
     .unwrap();
-    let empty_via_visitor =
-        scale_decode::visitor::decode_with_visitor(&mut &*empty_bytes, &type_id, &types, FooVisitor::new())
-            .unwrap();
+    let empty_via_visitor = scale_decode::visitor::decode_with_visitor(
+        &mut &*empty_bytes,
+        &type_id,
+        &types,
+        FooVisitor::new(),
+    )
+    .unwrap();
 
     assert_eq!(bar, bar_via_decode_as_type);
     assert_eq!(bar, bar_via_visitor);

--- a/scale-decode/examples/enum_decode_as_type.rs
+++ b/scale-decode/examples/enum_decode_as_type.rs
@@ -53,18 +53,18 @@ impl IntoVisitor for Foo {
 // implementation for free (and it will compose nicely with other types that implement `DecodeAsType`).
 // We can opt not to do this if we prefer.
 impl<R: TypeResolver> Visitor for FooVisitor<R> {
-    type Value<'scale, 'info> = Foo;
+    type Value<'scale, 'resolver> = Foo;
     type Error = Error;
     type TypeResolver = R;
 
     // We have opted here to be quite flexible in what we support; we'll happily ignore fields in the input that we
     // don't care about and support unnamed to named fields. You could choose to be more strict if you prefer. We also
     // add context to any errors coming from decoding sub-types via `.map_err(|e| e.at_x(..))` calls.
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut scale_decode::visitor::types::Variant<'scale, 'info, Self::TypeResolver>,
+        value: &mut scale_decode::visitor::types::Variant<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.name() == "Bar" {
             // Here we choose to support decoding named or unnamed fields into our Bar variant.
             let fields = value.fields();

--- a/scale-decode/examples/struct_decode_as_type.rs
+++ b/scale-decode/examples/struct_decode_as_type.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use codec::Encode;
-use scale_decode::{error::ErrorKind, DecodeAsType, Error, IntoVisitor, Visitor, TypeResolver, visitor::TypeIdFor};
+use scale_decode::{
+    error::ErrorKind, visitor::TypeIdFor, DecodeAsType, Error, IntoVisitor, TypeResolver, Visitor,
+};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
@@ -31,7 +33,7 @@ struct Foo {
 // Define a struct that will be our `Visitor` capable of decoding to a `Foo`.
 struct FooVisitor<R>(PhantomData<R>);
 
-impl <R> FooVisitor<R> {
+impl<R> FooVisitor<R> {
     fn new() -> Self {
         Self(PhantomData)
     }
@@ -49,7 +51,7 @@ impl IntoVisitor for Foo {
 // any error type that can be converted into a `scale_decode::Error`), we'll also get a `DecodeAsType`
 // implementation for free (and it will compose nicely with other types that implement `DecodeAsType`).
 // We can opt not to do this if we prefer.
-impl <R: TypeResolver> Visitor for FooVisitor<R> {
+impl<R: TypeResolver> Visitor for FooVisitor<R> {
     type Value<'scale, 'info> = Foo;
     type Error = Error;
     type TypeResolver = R;
@@ -122,9 +124,13 @@ fn main() {
     let foo_via_decode_as_type_arc =
         <std::sync::Arc<Foo>>::decode_as_type(&mut &*foo_bytes, &type_id, &types).unwrap();
     // Or we can also manually use our `Visitor` impl:
-    let foo_via_visitor =
-        scale_decode::visitor::decode_with_visitor(&mut &*foo_bytes, &type_id, &types, FooVisitor::new())
-            .unwrap();
+    let foo_via_visitor = scale_decode::visitor::decode_with_visitor(
+        &mut &*foo_bytes,
+        &type_id,
+        &types,
+        FooVisitor::new(),
+    )
+    .unwrap();
 
     assert_eq!(foo_original, foo_via_decode_as_type);
     assert_eq!(&foo_original, &*foo_via_decode_as_type_arc);

--- a/scale-decode/examples/struct_decode_as_type.rs
+++ b/scale-decode/examples/struct_decode_as_type.rs
@@ -52,7 +52,7 @@ impl IntoVisitor for Foo {
 // implementation for free (and it will compose nicely with other types that implement `DecodeAsType`).
 // We can opt not to do this if we prefer.
 impl<R: TypeResolver> Visitor for FooVisitor<R> {
-    type Value<'scale, 'info> = Foo;
+    type Value<'scale, 'resolver> = Foo;
     type Error = Error;
     type TypeResolver = R;
 
@@ -60,11 +60,11 @@ impl<R: TypeResolver> Visitor for FooVisitor<R> {
     // unnamed fields (matching by field index if unnamed) and add context to errors via
     // `.map_err(|e| e.at_x(..))` calls to give back more precise information about where
     // decoding failed, if it does.
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut scale_decode::visitor::types::Composite<'scale, 'info, Self::TypeResolver>,
+        value: &mut scale_decode::visitor::types::Composite<'scale, 'resolver, Self::TypeResolver>,
         type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.has_unnamed_fields() {
             // handle it like a tuple if there are unnamed fields in it:
             return self.visit_tuple(&mut value.as_tuple(), type_id);
@@ -87,11 +87,11 @@ impl<R: TypeResolver> Visitor for FooVisitor<R> {
     }
 
     // If we like, we can also support decoding from tuples of matching lengths:
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        value: &mut scale_decode::visitor::types::Tuple<'scale, 'info, Self::TypeResolver>,
+        value: &mut scale_decode::visitor::types::Tuple<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.remaining() != 2 {
             return Err(Error::new(ErrorKind::WrongLength {
                 actual_len: value.remaining(),

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -16,12 +16,12 @@
 use std::marker::PhantomData;
 
 use codec::Encode;
-use scale_decode::TypeResolver;
 use scale_decode::visitor::{
     self,
     types::{Array, BitSequence, Composite, Sequence, Str, Tuple, Variant},
-    TypeIdFor
+    TypeIdFor,
 };
+use scale_decode::TypeResolver;
 
 // A custom type we'd like to decode into:
 #[derive(Debug, PartialEq)]
@@ -53,13 +53,13 @@ enum Value {
 // values into this type:
 struct ValueVisitor<R>(PhantomData<R>);
 
-impl <R> ValueVisitor<R> {
+impl<R> ValueVisitor<R> {
     fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl <R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
+impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
     type Value<'scale, 'info> = Value;
     type Error = visitor::DecodeError;
     type TypeResolver = R;
@@ -263,8 +263,13 @@ fn main() {
 
     // Use scale_decode + type information to decode these bytes into our Value type:
     assert_eq!(
-        scale_decode::visitor::decode_with_visitor(&mut &*bytes, &type_id, &types, ValueVisitor::new())
-            .unwrap(),
+        scale_decode::visitor::decode_with_visitor(
+            &mut &*bytes,
+            &type_id,
+            &types,
+            ValueVisitor::new()
+        )
+        .unwrap(),
         Value::Variant(
             "Bar".to_owned(),
             vec![

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use codec::Encode;
-use std::marker::PhantomData;
-use scale_decode::TypeResolver;
 use scale_decode::visitor::{
     self,
     types::{Array, BitSequence, Composite, Sequence, Str, Tuple, Variant},
     TypeIdFor,
 };
+use scale_decode::TypeResolver;
+use std::marker::PhantomData;
 
 // A custom type we'd like to decode into:
 #[derive(Debug, PartialEq)]

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -60,113 +60,113 @@ impl<R> ValueVisitor<R> {
 }
 
 impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
-    type Value<'scale, 'info> = Value;
+    type Value<'scale, 'resolver> = Value;
     type Error = visitor::DecodeError;
     type TypeResolver = R;
 
-    fn visit_bool<'scale, 'info>(
+    fn visit_bool<'scale, 'resolver>(
         self,
         value: bool,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Bool(value))
     }
-    fn visit_char<'scale, 'info>(
+    fn visit_char<'scale, 'resolver>(
         self,
         value: char,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Char(value))
     }
-    fn visit_u8<'scale, 'info>(
+    fn visit_u8<'scale, 'resolver>(
         self,
         value: u8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U8(value))
     }
-    fn visit_u16<'scale, 'info>(
+    fn visit_u16<'scale, 'resolver>(
         self,
         value: u16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U16(value))
     }
-    fn visit_u32<'scale, 'info>(
+    fn visit_u32<'scale, 'resolver>(
         self,
         value: u32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U32(value))
     }
-    fn visit_u64<'scale, 'info>(
+    fn visit_u64<'scale, 'resolver>(
         self,
         value: u64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U64(value))
     }
-    fn visit_u128<'scale, 'info>(
+    fn visit_u128<'scale, 'resolver>(
         self,
         value: u128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U128(value))
     }
-    fn visit_u256<'scale, 'info>(
+    fn visit_u256<'scale, 'resolver>(
         self,
         value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U256(*value))
     }
-    fn visit_i8<'scale, 'info>(
+    fn visit_i8<'scale, 'resolver>(
         self,
         value: i8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I8(value))
     }
-    fn visit_i16<'scale, 'info>(
+    fn visit_i16<'scale, 'resolver>(
         self,
         value: i16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I16(value))
     }
-    fn visit_i32<'scale, 'info>(
+    fn visit_i32<'scale, 'resolver>(
         self,
         value: i32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I32(value))
     }
-    fn visit_i64<'scale, 'info>(
+    fn visit_i64<'scale, 'resolver>(
         self,
         value: i64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I64(value))
     }
-    fn visit_i128<'scale, 'info>(
+    fn visit_i128<'scale, 'resolver>(
         self,
         value: i128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I128(value))
     }
-    fn visit_i256<'scale, 'info>(
+    fn visit_i256<'scale, 'resolver>(
         self,
         value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I256(*value))
     }
-    fn visit_sequence<'scale, 'info>(
+    fn visit_sequence<'scale, 'resolver>(
         self,
-        value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+        value: &mut Sequence<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -174,11 +174,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Sequence(vals))
     }
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+        value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         for item in value.by_ref() {
             let item = item?;
@@ -188,11 +188,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Composite(vals))
     }
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+        value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -200,18 +200,18 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Tuple(vals))
     }
-    fn visit_str<'scale, 'info>(
+    fn visit_str<'scale, 'resolver>(
         self,
         value: &mut Str<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+        value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         let fields = value.fields();
         for item in fields.by_ref() {
@@ -222,11 +222,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Variant(value.name().to_owned(), vals))
     }
-    fn visit_array<'scale, 'info>(
+    fn visit_array<'scale, 'resolver>(
         self,
-        value: &mut Array<'scale, 'info, Self::TypeResolver>,
+        value: &mut Array<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
@@ -234,11 +234,11 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         }
         Ok(Value::Array(vals))
     }
-    fn visit_bitsequence<'scale, 'info>(
+    fn visit_bitsequence<'scale, 'resolver>(
         self,
         value: &mut BitSequence<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
     }

--- a/scale-decode/examples/visitor.rs
+++ b/scale-decode/examples/visitor.rs
@@ -12,16 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use std::marker::PhantomData;
-
 use codec::Encode;
+use std::marker::PhantomData;
+use scale_decode::TypeResolver;
 use scale_decode::visitor::{
     self,
     types::{Array, BitSequence, Composite, Sequence, Str, Tuple, Variant},
     TypeIdFor,
 };
-use scale_decode::TypeResolver;
 
 // A custom type we'd like to decode into:
 #[derive(Debug, PartialEq)]
@@ -50,7 +48,9 @@ enum Value {
 }
 
 // Implement the `Visitor` trait to define how to go from SCALE
-// values into this type:
+// values into this type. Here, we are choosing to be generic over
+// how types are resolved, which is a good default choice when creating
+// a visitor unless you rely on a specific type resolver/ID type.
 struct ValueVisitor<R>(PhantomData<R>);
 
 impl<R> ValueVisitor<R> {

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -376,8 +376,6 @@ impl<T: IntoVisitor> IntoVisitor for BTreeMap<String, T> {
     }
 }
 
-// impl_into_visitor!(BTreeMap<String, T> where T: IntoVisitor);
-
 impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<Option<T>, R> {
     type Error = Error;
     type Value<'scale, 'resolver> = Option<T>;

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -577,7 +577,7 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
                 }
             }
 
-            // If error decoding, or false, just fall back to default behavious and don't try to decode as inner.
+            // If error decoding, or false, just fall back to default behaviour and don't try to decode as inner.
             if let Err(_) | Ok(false) = types.resolve_type(type_id, TryDecodeAsInner(PhantomData)) {
                 return DecodeAsTypeResult::Skipped(self);
             }

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -561,7 +561,7 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
 
             // Match on the resolved kind; try to decode as inner type if it's not a
             // composite, tuple, or a type ID we can't find. Else fall back to default.
-            struct TryDecodeAsInner<TypeId>(std::marker::PhantomData<TypeId>);
+            struct TryDecodeAsInner<TypeId>(PhantomData<TypeId>);
             impl<'resolver, TypeId: scale_type_resolver::TypeId + 'resolver>
                 ResolvedTypeVisitor<'resolver> for TryDecodeAsInner<TypeId>
             {
@@ -578,9 +578,7 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
             }
 
             // If error decoding, or false, just fall back to default behavious and don't try to decode as inner.
-            if let Err(_) | Ok(false) =
-                types.resolve_type(type_id, TryDecodeAsInner(std::marker::PhantomData))
-            {
+            if let Err(_) | Ok(false) = types.resolve_type(type_id, TryDecodeAsInner(PhantomData)) {
                 return DecodeAsTypeResult::Skipped(self);
             }
 

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -67,21 +67,21 @@ macro_rules! impl_into_visitor {
 /// Ignore single-field tuples/composites and visit the single field inside instead.
 macro_rules! visit_single_field_composite_tuple_impls {
     ($type_resolver:ident) => {
-        fn visit_composite<'scale, 'info>(
+        fn visit_composite<'scale, 'resolver>(
             self,
-            value: &mut $crate::visitor::types::Composite<'scale, 'info, $type_resolver>,
+            value: &mut $crate::visitor::types::Composite<'scale, 'resolver, $type_resolver>,
             _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             if value.remaining() != 1 {
                 return self.visit_unexpected($crate::visitor::Unexpected::Composite);
             }
             value.decode_item(self).unwrap()
         }
-        fn visit_tuple<'scale, 'info>(
+        fn visit_tuple<'scale, 'resolver>(
             self,
-            value: &mut $crate::visitor::types::Tuple<'scale, 'info, $type_resolver>,
+            value: &mut $crate::visitor::types::Tuple<'scale, 'resolver, $type_resolver>,
             _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             if value.remaining() != 1 {
                 return self.visit_unexpected($crate::visitor::Unexpected::Tuple);
             }
@@ -92,14 +92,14 @@ macro_rules! visit_single_field_composite_tuple_impls {
 
 impl<R: TypeResolver> Visitor for BasicVisitor<char, R> {
     type Error = Error;
-    type Value<'scale, 'info> = char;
+    type Value<'scale, 'resolver> = char;
     type TypeResolver = R;
 
-    fn visit_char<'scale, 'info>(
+    fn visit_char<'scale, 'resolver>(
         self,
         value: char,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(value)
     }
     visit_single_field_composite_tuple_impls!(R);
@@ -108,14 +108,14 @@ impl_into_visitor!(char);
 
 impl<R: TypeResolver> Visitor for BasicVisitor<bool, R> {
     type Error = Error;
-    type Value<'scale, 'info> = bool;
+    type Value<'scale, 'resolver> = bool;
     type TypeResolver = R;
 
-    fn visit_bool<'scale, 'info>(
+    fn visit_bool<'scale, 'resolver>(
         self,
         value: bool,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(value)
     }
     visit_single_field_composite_tuple_impls!(R);
@@ -124,14 +124,14 @@ impl_into_visitor!(bool);
 
 impl<R: TypeResolver> Visitor for BasicVisitor<String, R> {
     type Error = Error;
-    type Value<'scale, 'info> = String;
+    type Value<'scale, 'resolver> = String;
     type TypeResolver = R;
 
-    fn visit_str<'scale, 'info>(
+    fn visit_str<'scale, 'resolver>(
         self,
         value: &mut Str<'scale>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let s = value.as_str()?.to_owned();
         Ok(s)
     }
@@ -141,14 +141,14 @@ impl_into_visitor!(String);
 
 impl<R: TypeResolver> Visitor for BasicVisitor<Bits, R> {
     type Error = Error;
-    type Value<'scale, 'info> = Bits;
+    type Value<'scale, 'resolver> = Bits;
     type TypeResolver = R;
 
-    fn visit_bitsequence<'scale, 'info>(
+    fn visit_bitsequence<'scale, 'resolver>(
         self,
         value: &mut BitSequence<'scale>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         value
             .decode()?
             .collect::<Result<Bits, _>>()
@@ -160,25 +160,25 @@ impl_into_visitor!(Bits);
 
 impl<T, R: TypeResolver> Visitor for BasicVisitor<PhantomData<T>, R> {
     type Error = Error;
-    type Value<'scale, 'info> = PhantomData<T>;
+    type Value<'scale, 'resolver> = PhantomData<T>;
     type TypeResolver = R;
 
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        value: &mut Tuple<'scale, 'info, R>,
+        value: &mut Tuple<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.remaining() == 0 {
             Ok(PhantomData)
         } else {
             self.visit_unexpected(visitor::Unexpected::Tuple)
         }
     }
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut Composite<'scale, 'info, R>,
+        value: &mut Composite<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.remaining() == 0 {
             Ok(PhantomData)
         } else {
@@ -198,16 +198,16 @@ macro_rules! impl_into_visitor_like {
             Resolver: TypeResolver,
             $( $($where)* )?
         {
-            type Value<'scale, 'info> = $target $(< $($param),* >)?;
+            type Value<'scale, 'resolver> = $target $(< $($param),* >)?;
             type Error = <<$source as IntoVisitor>::AnyVisitor<Resolver> as Visitor>::Error;
             type TypeResolver = Resolver;
 
-            fn unchecked_decode_as_type<'scale, 'info>(
+            fn unchecked_decode_as_type<'scale, 'resolver>(
                 self,
                 input: &mut &'scale [u8],
                 type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-                types: &'info Self::TypeResolver,
-            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+                types: &'resolver Self::TypeResolver,
+            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>> {
                 // Use the source visitor to decode into some type:
                 let inner_res = decode_with_visitor(input, type_id, types, <$source>::into_visitor());
                 // map this type into our desired output and return it:
@@ -235,16 +235,16 @@ where
     <T as ToOwned>::Owned: IntoVisitor,
     R: TypeResolver,
 {
-    type Value<'scale, 'info> = Cow<'a, T>;
+    type Value<'scale, 'resolver> = Cow<'a, T>;
     type Error = <<<T as ToOwned>::Owned as IntoVisitor>::AnyVisitor<R> as Visitor>::Error;
     type TypeResolver = R;
 
-    fn unchecked_decode_as_type<'scale, 'info>(
+    fn unchecked_decode_as_type<'scale, 'resolver>(
         self,
         input: &mut &'scale [u8],
         type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-        types: &'info Self::TypeResolver,
-    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+        types: &'resolver Self::TypeResolver,
+    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>> {
         // Use the ToOwned visitor to decode into some type:
         let inner_res =
             decode_with_visitor(input, type_id, types, <<T as ToOwned>::Owned>::into_visitor());
@@ -272,22 +272,22 @@ macro_rules! impl_decode_seq_via_collect {
             Resolver: TypeResolver,
             $( $($where)* )?
         {
-            type Value<'scale, 'info> = $ty<$generic>;
+            type Value<'scale, 'resolver> = $ty<$generic>;
             type Error = Error;
             type TypeResolver = Resolver;
 
-            fn visit_sequence<'scale, 'info>(
+            fn visit_sequence<'scale, 'resolver>(
                 self,
-                value: &mut Sequence<'scale, 'info, Resolver>,
+                value: &mut Sequence<'scale, 'resolver, Resolver>,
                 _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 decode_items_using::<_, _, $generic>(value).collect()
             }
-            fn visit_array<'scale, 'info>(
+            fn visit_array<'scale, 'resolver>(
                 self,
-                value: &mut Array<'scale, 'info, Resolver>,
+                value: &mut Array<'scale, 'resolver, Resolver>,
                 _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 decode_items_using::<_, _, $generic>(value).collect()
             }
 
@@ -315,22 +315,22 @@ macro_rules! array_method_impl {
     }};
 }
 impl<const N: usize, T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<[T; N], R> {
-    type Value<'scale, 'info> = [T; N];
+    type Value<'scale, 'resolver> = [T; N];
     type Error = Error;
     type TypeResolver = R;
 
-    fn visit_sequence<'scale, 'info>(
+    fn visit_sequence<'scale, 'resolver>(
         self,
-        value: &mut Sequence<'scale, 'info, R>,
+        value: &mut Sequence<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         array_method_impl!(value, [T; N])
     }
-    fn visit_array<'scale, 'info>(
+    fn visit_array<'scale, 'resolver>(
         self,
-        value: &mut Array<'scale, 'info, R>,
+        value: &mut Array<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         array_method_impl!(value, [T; N])
     }
 
@@ -345,14 +345,14 @@ impl<const N: usize, T: IntoVisitor> IntoVisitor for [T; N] {
 
 impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<BTreeMap<String, T>, R> {
     type Error = Error;
-    type Value<'scale, 'info> = BTreeMap<String, T>;
+    type Value<'scale, 'resolver> = BTreeMap<String, T>;
     type TypeResolver = R;
 
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut Composite<'scale, 'info, R>,
+        value: &mut Composite<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut map = BTreeMap::new();
         while value.remaining() > 0 {
             // Get the name. If no name, skip over the corresponding value.
@@ -380,14 +380,14 @@ impl<T: IntoVisitor> IntoVisitor for BTreeMap<String, T> {
 
 impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<Option<T>, R> {
     type Error = Error;
-    type Value<'scale, 'info> = Option<T>;
+    type Value<'scale, 'resolver> = Option<T>;
     type TypeResolver = R;
 
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut Variant<'scale, 'info, R>,
+        value: &mut Variant<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.name() == "Some" && value.fields().remaining() == 1 {
             let val = value
                 .fields()
@@ -411,14 +411,14 @@ impl_into_visitor!(Option<T> where T: IntoVisitor);
 
 impl<T: IntoVisitor, E: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<Result<T, E>, R> {
     type Error = Error;
-    type Value<'scale, 'info> = Result<T, E>;
+    type Value<'scale, 'resolver> = Result<T, E>;
     type TypeResolver = R;
 
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut Variant<'scale, 'info, R>,
+        value: &mut Variant<'scale, 'resolver, R>,
         _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         if value.name() == "Ok" && value.fields().remaining() == 1 {
             let val = value
                 .fields()
@@ -449,11 +449,11 @@ impl_into_visitor!(Result<T, E> where T: IntoVisitor, E: IntoVisitor);
 // Impl Visitor/DecodeAsType for all primitive number types
 macro_rules! visit_number_fn_impl {
     ($name:ident : $ty:ty where |$res:ident| $expr:expr) => {
-        fn $name<'scale, 'info>(
+        fn $name<'scale, 'resolver>(
             self,
             value: $ty,
             _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let $res = value;
             let n = $expr.ok_or_else(|| {
                 Error::new(ErrorKind::NumberOutOfRange { value: value.to_string() })
@@ -464,10 +464,10 @@ macro_rules! visit_number_fn_impl {
 }
 macro_rules! visit_number_impl {
     ($ty:ident where |$res:ident| $expr:expr) => {
-        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unnecessary_fallible_conversions, clippy::useless_conversion)]
         impl <R: TypeResolver> Visitor for BasicVisitor<$ty, R> {
             type Error = Error;
-            type Value<'scale, 'info> = $ty;
+            type Value<'scale, 'resolver> = $ty;
             type TypeResolver = R;
 
             visit_number_fn_impl!(visit_u8: u8 where |$res| $expr);
@@ -551,19 +551,19 @@ macro_rules! tuple_method_impl {
 
 macro_rules! decode_inner_type_when_one_tuple_entry {
     ($t:ident) => {
-        fn unchecked_decode_as_type<'scale, 'info>(
+        fn unchecked_decode_as_type<'scale, 'resolver>(
             self,
             input: &mut &'scale [u8],
             type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-            types: &'info Self::TypeResolver,
-        ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+            types: &'resolver Self::TypeResolver,
+        ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>> {
             use scale_type_resolver::{ResolvedTypeVisitor, UnhandledKind};
 
             // Match on the resolved kind; try to decode as inner type if it's not a
             // composite, tuple, or a type ID we can't find. Else fall back to default.
             struct TryDecodeAsInner<TypeId>(std::marker::PhantomData<TypeId>);
-            impl<'info, TypeId: scale_type_resolver::TypeId + 'info> ResolvedTypeVisitor<'info>
-                for TryDecodeAsInner<TypeId>
+            impl<'resolver, TypeId: scale_type_resolver::TypeId + 'resolver>
+                ResolvedTypeVisitor<'resolver> for TryDecodeAsInner<TypeId>
             {
                 type TypeId = TypeId;
                 type Value = bool;
@@ -601,7 +601,7 @@ macro_rules! impl_decode_tuple {
             Resolver: TypeResolver,
             $($t: IntoVisitor,)*
         {
-            type Value<'scale, 'info> = ($($t,)*);
+            type Value<'scale, 'resolver> = ($($t,)*);
             type Error = Error;
             type TypeResolver = Resolver;
 
@@ -609,18 +609,18 @@ macro_rules! impl_decode_tuple {
             // isn't a tuple or composite, then decode the inner type and add the tuple.
             decode_inner_type_when_one_tuple_entry!($($t)*);
 
-            fn visit_composite<'scale, 'info>(
+            fn visit_composite<'scale, 'resolver>(
                 self,
-                value: &mut Composite<'scale, 'info, Resolver>,
+                value: &mut Composite<'scale, 'resolver, Resolver>,
                 _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 tuple_method_impl!(($($t,)*), value)
             }
-            fn visit_tuple<'scale, 'info>(
+            fn visit_tuple<'scale, 'resolver>(
                 self,
-                value: &mut Tuple<'scale, 'info, Resolver>,
+                value: &mut Tuple<'scale, 'resolver, Resolver>,
                 _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 tuple_method_impl!(($($t,)*), value)
             }
         }
@@ -639,7 +639,7 @@ macro_rules! impl_decode_tuple {
         impl < $($t),* > DecodeAsFields for ($($t,)*)
         where $( $t: IntoVisitor, )*
         {
-            fn decode_as_fields<'info, Resolver: TypeResolver>(input: &mut &[u8], fields: &mut dyn FieldIter<'info, Resolver::TypeId>, types: &'info Resolver) -> Result<Self, Error> {
+            fn decode_as_fields<'resolver, Resolver: TypeResolver>(input: &mut &[u8], fields: &mut dyn FieldIter<'resolver, Resolver::TypeId>, types: &'resolver Resolver) -> Result<Self, Error> {
                 let mut composite = crate::visitor::types::Composite::new(input, fields, types, false);
 
                 // [jsdw] TODO: Passing a "default type ID" to a visitor just to satisfy the signature is
@@ -680,13 +680,13 @@ impl_decode_tuple!(A B C D E F G H I J K L M N O P Q R S T);
 // ^ Note: We make sure to support as many as parity-scale-codec's impls do.
 
 /// This takes anything that can decode a stream if items and return an iterator over them.
-fn decode_items_using<'a, 'scale, 'info, R, D, T>(
+fn decode_items_using<'a, 'scale, 'resolver, R, D, T>(
     decoder: &'a mut D,
 ) -> impl Iterator<Item = Result<T, Error>> + 'a
 where
     T: IntoVisitor,
     R: TypeResolver,
-    D: DecodeItemIterator<'scale, 'info, R>,
+    D: DecodeItemIterator<'scale, 'resolver, R>,
 {
     let mut idx = 0;
     core::iter::from_fn(move || {

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -71,7 +71,7 @@ macro_rules! visit_single_field_composite_tuple_impls {
         fn visit_composite<'scale, 'info>(
             self,
             value: &mut $crate::visitor::types::Composite<'scale, 'info, $type_resolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             if value.remaining() != 1 {
                 return self.visit_unexpected($crate::visitor::Unexpected::Composite);
@@ -81,7 +81,7 @@ macro_rules! visit_single_field_composite_tuple_impls {
         fn visit_tuple<'scale, 'info>(
             self,
             value: &mut $crate::visitor::types::Tuple<'scale, 'info, $type_resolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             if value.remaining() != 1 {
                 return self.visit_unexpected($crate::visitor::Unexpected::Tuple);
@@ -99,7 +99,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<char, R> {
     fn visit_char<'scale, 'info>(
         self,
         value: char,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(value)
     }
@@ -115,7 +115,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<bool, R> {
     fn visit_bool<'scale, 'info>(
         self,
         value: bool,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         Ok(value)
     }
@@ -131,7 +131,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<String, R> {
     fn visit_str<'scale, 'info>(
         self,
         value: &mut Str<'scale>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let s = value.as_str()?.to_owned();
         Ok(s)
@@ -148,7 +148,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<Bits, R> {
     fn visit_bitsequence<'scale, 'info>(
         self,
         value: &mut BitSequence<'scale>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         value
             .decode()?
@@ -167,7 +167,7 @@ impl <T, R: TypeResolver> Visitor for BasicVisitor<PhantomData<T>, R> {
     fn visit_tuple<'scale, 'info>(
         self,
         value: &mut Tuple<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.remaining() == 0 {
             Ok(PhantomData)
@@ -178,7 +178,7 @@ impl <T, R: TypeResolver> Visitor for BasicVisitor<PhantomData<T>, R> {
     fn visit_composite<'scale, 'info>(
         self,
         value: &mut Composite<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.remaining() == 0 {
             Ok(PhantomData)
@@ -206,7 +206,7 @@ macro_rules! impl_into_visitor_like {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
                 types: &'info Self::TypeResolver,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
                 // Use the source visitor to decode into some type:
@@ -243,7 +243,7 @@ where
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         // Use the ToOwned visitor to decode into some type:
@@ -280,14 +280,14 @@ macro_rules! impl_decode_seq_via_collect {
             fn visit_sequence<'scale, 'info>(
                 self,
                 value: &mut Sequence<'scale, 'info, Resolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 decode_items_using::<_, _, $generic>(value).collect()
             }
             fn visit_array<'scale, 'info>(
                 self,
                 value: &mut Array<'scale, 'info, Resolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 decode_items_using::<_, _, $generic>(value).collect()
             }
@@ -323,14 +323,14 @@ impl<const N: usize, T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<[
     fn visit_sequence<'scale, 'info>(
         self,
         value: &mut Sequence<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         array_method_impl!(value, [T; N])
     }
     fn visit_array<'scale, 'info>(
         self,
         value: &mut Array<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         array_method_impl!(value, [T; N])
     }
@@ -352,7 +352,7 @@ impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<BTreeMap<String, 
     fn visit_composite<'scale, 'info>(
         self,
         value: &mut Composite<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         let mut map = BTreeMap::new();
         while value.remaining() > 0 {
@@ -387,7 +387,7 @@ impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<Option<T>, R> {
     fn visit_variant<'scale, 'info>(
         self,
         value: &mut Variant<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.name() == "Some" && value.fields().remaining() == 1 {
             let val = value
@@ -418,7 +418,7 @@ impl<T: IntoVisitor, E: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<R
     fn visit_variant<'scale, 'info>(
         self,
         value: &mut Variant<'scale, 'info, R>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         if value.name() == "Ok" && value.fields().remaining() == 1 {
             let val = value
@@ -453,7 +453,7 @@ macro_rules! visit_number_fn_impl {
         fn $name<'scale, 'info>(
             self,
             value: $ty,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let $res = value;
             let n = $expr.ok_or_else(|| {
@@ -555,7 +555,7 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
         fn unchecked_decode_as_type<'scale, 'info>(
             self,
             input: &mut &'scale [u8],
-            type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             types: &'info Self::TypeResolver,
         ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
             use scale_type_resolver::{
@@ -566,10 +566,10 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
             // Match on the resolved kind; try to decode as inner type if it's not a
             // composite, tuple, or a type ID we can't find. Else fall back to default.
             struct TryDecodeAsInner<TypeId>(std::marker::PhantomData<TypeId>);
-            impl <TypeId: scale_type_resolver::TypeId> ResolvedTypeVisitor for TryDecodeAsInner<TypeId> {
+            impl <'info, TypeId: scale_type_resolver::TypeId + 'info> ResolvedTypeVisitor<'info> for TryDecodeAsInner<TypeId> {
                 type TypeId = TypeId;
-                type Value<'a> = bool;
-                fn visit_unhandled<'a>(self, _type_id: Self::TypeId, kind: UnhandledKind) -> Self::Value<'a> {
+                type Value = bool;
+                fn visit_unhandled(self, kind: UnhandledKind) -> Self::Value {
                     match kind {
                         UnhandledKind::Composite |
                         UnhandledKind::Tuple |
@@ -612,14 +612,14 @@ macro_rules! impl_decode_tuple {
             fn visit_composite<'scale, 'info>(
                 self,
                 value: &mut Composite<'scale, 'info, Resolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 tuple_method_impl!(($($t,)*), value)
             }
             fn visit_tuple<'scale, 'info>(
                 self,
                 value: &mut Tuple<'scale, 'info, Resolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 tuple_method_impl!(($($t,)*), value)
             }
@@ -641,7 +641,10 @@ macro_rules! impl_decode_tuple {
         {
             fn decode_as_fields<'info, Resolver: TypeResolver>(input: &mut &[u8], fields: &mut dyn FieldIter<'info, Resolver::TypeId>, types: &'info Resolver) -> Result<Self, Error> {
                 let mut composite = crate::visitor::types::Composite::new(input, fields, types, false);
-                let val = <($($t,)*)>::into_visitor().visit_composite(&mut composite, Default::default());
+
+                // [jsdw] TODO: Passing a "default type ID" to a visitor just to satisfy the signature is
+                // a bit hideous (and requires `TypeId: Default`). Can we re-work this to avoid?
+                let val = <($($t,)*)>::into_visitor().visit_composite(&mut composite, &Default::default());
 
                 // Skip over bytes that we decoded:
                 composite.skip_decoding()?;
@@ -720,7 +723,7 @@ mod test {
         let (type_id, types) = make_type::<T>();
         let encoded = a.encode();
         let decoded =
-            B::decode_as_type(&mut &*encoded, type_id, &types).expect("should be able to decode");
+            B::decode_as_type(&mut &*encoded, &type_id, &types).expect("should be able to decode");
         assert_eq!(&decoded, b);
     }
 
@@ -768,11 +771,11 @@ mod test {
         let new_foo = match &types.resolve(ty).unwrap().type_def {
             scale_info::TypeDef::Composite(c) => {
                 let mut field_iter =
-                    c.fields.iter().map(|f| Field::new(f.ty.id, f.name.as_deref()));
+                    c.fields.iter().map(|f| Field::new(&f.ty.id, f.name.as_deref()));
                 Foo::decode_as_fields(foo_encoded_cursor, &mut field_iter, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {
-                let mut field_iter = t.fields.iter().map(|f| Field::unnamed(f.id));
+                let mut field_iter = t.fields.iter().map(|f| Field::unnamed(&f.id));
                 Foo::decode_as_fields(foo_encoded_cursor, &mut field_iter, &types).unwrap()
             }
             _ => {

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -19,8 +19,7 @@ mod primitive_types;
 use crate::{
     error::{Error, ErrorKind},
     visitor::{
-        self, decode_with_visitor, types::*, DecodeAsTypeResult, DecodeItemIterator,
-        Visitor,
+        self, decode_with_visitor, types::*, DecodeAsTypeResult, DecodeItemIterator, Visitor,
     },
     DecodeAsFields, FieldIter, IntoVisitor,
 };
@@ -91,7 +90,7 @@ macro_rules! visit_single_field_composite_tuple_impls {
     };
 }
 
-impl <R: TypeResolver> Visitor for BasicVisitor<char, R> {
+impl<R: TypeResolver> Visitor for BasicVisitor<char, R> {
     type Error = Error;
     type Value<'scale, 'info> = char;
     type TypeResolver = R;
@@ -107,7 +106,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<char, R> {
 }
 impl_into_visitor!(char);
 
-impl <R: TypeResolver> Visitor for BasicVisitor<bool, R> {
+impl<R: TypeResolver> Visitor for BasicVisitor<bool, R> {
     type Error = Error;
     type Value<'scale, 'info> = bool;
     type TypeResolver = R;
@@ -123,7 +122,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<bool, R> {
 }
 impl_into_visitor!(bool);
 
-impl <R: TypeResolver> Visitor for BasicVisitor<String, R> {
+impl<R: TypeResolver> Visitor for BasicVisitor<String, R> {
     type Error = Error;
     type Value<'scale, 'info> = String;
     type TypeResolver = R;
@@ -140,7 +139,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<String, R> {
 }
 impl_into_visitor!(String);
 
-impl <R: TypeResolver> Visitor for BasicVisitor<Bits, R> {
+impl<R: TypeResolver> Visitor for BasicVisitor<Bits, R> {
     type Error = Error;
     type Value<'scale, 'info> = Bits;
     type TypeResolver = R;
@@ -159,7 +158,7 @@ impl <R: TypeResolver> Visitor for BasicVisitor<Bits, R> {
 }
 impl_into_visitor!(Bits);
 
-impl <T, R: TypeResolver> Visitor for BasicVisitor<PhantomData<T>, R> {
+impl<T, R: TypeResolver> Visitor for BasicVisitor<PhantomData<T>, R> {
     type Error = Error;
     type Value<'scale, 'info> = PhantomData<T>;
     type TypeResolver = R;
@@ -370,7 +369,7 @@ impl<T: IntoVisitor, R: TypeResolver> Visitor for BasicVisitor<BTreeMap<String, 
         Ok(map)
     }
 }
-impl <T: IntoVisitor> IntoVisitor for BTreeMap<String, T> {
+impl<T: IntoVisitor> IntoVisitor for BTreeMap<String, T> {
     type AnyVisitor<R: TypeResolver> = BasicVisitor<BTreeMap<String, T>, R>;
     fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R> {
         BasicVisitor { _marker: core::marker::PhantomData }
@@ -558,29 +557,30 @@ macro_rules! decode_inner_type_when_one_tuple_entry {
             type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             types: &'info Self::TypeResolver,
         ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
-            use scale_type_resolver::{
-                ResolvedTypeVisitor,
-                UnhandledKind
-            };
+            use scale_type_resolver::{ResolvedTypeVisitor, UnhandledKind};
 
             // Match on the resolved kind; try to decode as inner type if it's not a
             // composite, tuple, or a type ID we can't find. Else fall back to default.
             struct TryDecodeAsInner<TypeId>(std::marker::PhantomData<TypeId>);
-            impl <'info, TypeId: scale_type_resolver::TypeId + 'info> ResolvedTypeVisitor<'info> for TryDecodeAsInner<TypeId> {
+            impl<'info, TypeId: scale_type_resolver::TypeId + 'info> ResolvedTypeVisitor<'info>
+                for TryDecodeAsInner<TypeId>
+            {
                 type TypeId = TypeId;
                 type Value = bool;
                 fn visit_unhandled(self, kind: UnhandledKind) -> Self::Value {
                     match kind {
-                        UnhandledKind::Composite |
-                        UnhandledKind::Tuple |
-                        UnhandledKind::NotFound => false,
-                        _ => true
+                        UnhandledKind::Composite
+                        | UnhandledKind::Tuple
+                        | UnhandledKind::NotFound => false,
+                        _ => true,
                     }
                 }
             }
 
             // If error decoding, or false, just fall back to default behavious and don't try to decode as inner.
-            if let Err(_) | Ok(false) = types.resolve_type(type_id, TryDecodeAsInner(std::marker::PhantomData)) {
+            if let Err(_) | Ok(false) =
+                types.resolve_type(type_id, TryDecodeAsInner(std::marker::PhantomData))
+            {
                 return DecodeAsTypeResult::Skipped(self);
             }
 

--- a/scale-decode/src/impls/primitive_types.rs
+++ b/scale-decode/src/impls/primitive_types.rs
@@ -19,28 +19,30 @@ use crate::{
     visitor::{decode_with_visitor, DecodeAsTypeResult, Visitor},
     IntoVisitor,
 };
+use scale_type_resolver::TypeResolver;
 use primitive_types::{H128, H160, H256, H384, H512, H768};
 
 macro_rules! impl_visitor {
     ($ty:ty: $len:literal) => {
-        impl Visitor for BasicVisitor<$ty> {
+        impl <R: TypeResolver> Visitor for BasicVisitor<$ty, R> {
             type Error = Error;
             type Value<'scale, 'info> = $ty;
+            type TypeResolver = R;
 
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                type_id: crate::visitor::TypeId,
-                types: &'info scale_info::PortableRegistry,
+                type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                types: &'info Self::TypeResolver,
             ) -> crate::visitor::DecodeAsTypeResult<
                 Self,
                 Result<Self::Value<'scale, 'info>, Self::Error>,
             > {
                 let res = decode_with_visitor(
                     input,
-                    type_id.0,
+                    type_id,
                     types,
-                    BasicVisitor::<[u8; $len / 8]> { _marker: core::marker::PhantomData },
+                    BasicVisitor::<[u8; $len / 8], R> { _marker: core::marker::PhantomData },
                 )
                 .map(|res| <$ty>::from(res));
                 DecodeAsTypeResult::Decoded(res)
@@ -48,8 +50,8 @@ macro_rules! impl_visitor {
         }
 
         impl IntoVisitor for $ty {
-            type Visitor = BasicVisitor<$ty>;
-            fn into_visitor() -> Self::Visitor {
+            type AnyVisitor<R: TypeResolver> = BasicVisitor<$ty, R>;
+            fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R> {
                 BasicVisitor { _marker: core::marker::PhantomData }
             }
         }

--- a/scale-decode/src/impls/primitive_types.rs
+++ b/scale-decode/src/impls/primitive_types.rs
@@ -19,12 +19,12 @@ use crate::{
     visitor::{decode_with_visitor, DecodeAsTypeResult, Visitor},
     IntoVisitor,
 };
-use scale_type_resolver::TypeResolver;
 use primitive_types::{H128, H160, H256, H384, H512, H768};
+use scale_type_resolver::TypeResolver;
 
 macro_rules! impl_visitor {
     ($ty:ty: $len:literal) => {
-        impl <R: TypeResolver> Visitor for BasicVisitor<$ty, R> {
+        impl<R: TypeResolver> Visitor for BasicVisitor<$ty, R> {
             type Error = Error;
             type Value<'scale, 'info> = $ty;
             type TypeResolver = R;

--- a/scale-decode/src/impls/primitive_types.rs
+++ b/scale-decode/src/impls/primitive_types.rs
@@ -26,17 +26,17 @@ macro_rules! impl_visitor {
     ($ty:ty: $len:literal) => {
         impl<R: TypeResolver> Visitor for BasicVisitor<$ty, R> {
             type Error = Error;
-            type Value<'scale, 'info> = $ty;
+            type Value<'scale, 'resolver> = $ty;
             type TypeResolver = R;
 
-            fn unchecked_decode_as_type<'scale, 'info>(
+            fn unchecked_decode_as_type<'scale, 'resolver>(
                 self,
                 input: &mut &'scale [u8],
                 type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
-                types: &'info Self::TypeResolver,
+                types: &'resolver Self::TypeResolver,
             ) -> crate::visitor::DecodeAsTypeResult<
                 Self,
-                Result<Self::Value<'scale, 'info>, Self::Error>,
+                Result<Self::Value<'scale, 'resolver>, Self::Error>,
             > {
                 let res = decode_with_visitor(
                     input,

--- a/scale-decode/src/impls/primitive_types.rs
+++ b/scale-decode/src/impls/primitive_types.rs
@@ -32,7 +32,7 @@ macro_rules! impl_visitor {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
                 types: &'info Self::TypeResolver,
             ) -> crate::visitor::DecodeAsTypeResult<
                 Self,

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -213,10 +213,10 @@ impl<T: Sized + IntoVisitor> DecodeAsType for T {
 /// for tuple and struct types, and is automatically implemented via the [`macro@DecodeAsType`] macro.
 pub trait DecodeAsFields: Sized {
     /// Given some bytes and some fields denoting their structure, attempt to decode.
-    fn decode_as_fields<'info, R: TypeResolver>(
+    fn decode_as_fields<'resolver, R: TypeResolver>(
         input: &mut &[u8],
-        fields: &mut dyn FieldIter<'info, R::TypeId>,
-        types: &'info R,
+        fields: &mut dyn FieldIter<'resolver, R::TypeId>,
+        types: &'resolver R,
     ) -> Result<Self, Error>;
 }
 
@@ -230,8 +230,8 @@ pub trait DecodeAsFields: Sized {
 // rather than rely on auto conversion, if they care about also being able to impl `DecodeAsType`.
 pub trait IntoVisitor {
     /// The visitor type used to decode SCALE encoded bytes to `Self`.
-    type AnyVisitor<R: TypeResolver>: for<'scale, 'info> visitor::Visitor<
-        Value<'scale, 'info> = Self,
+    type AnyVisitor<R: TypeResolver>: for<'scale, 'resolver> visitor::Visitor<
+        Value<'scale, 'resolver> = Self,
         Error = Error,
         TypeResolver = R,
     >;

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -169,7 +169,7 @@ pub trait DecodeAsType: Sized + IntoVisitor {
     /// not used in the course of decoding are still pointed to after decoding is complete.
     fn decode_as_type<R: TypeResolver>(
         input: &mut &[u8],
-        type_id: R::TypeId,
+        type_id: &R::TypeId,
         types: &R,
     ) -> Result<Self, Error> {
         Self::decode_as_type_maybe_compact(input, type_id, types, false)
@@ -183,7 +183,7 @@ pub trait DecodeAsType: Sized + IntoVisitor {
     #[doc(hidden)]
     fn decode_as_type_maybe_compact<R: TypeResolver>(
         input: &mut &[u8],
-        type_id: R::TypeId,
+        type_id: &R::TypeId,
         types: &R,
         is_compact: bool,
     ) -> Result<Self, Error>;
@@ -192,7 +192,7 @@ pub trait DecodeAsType: Sized + IntoVisitor {
 impl<T: Sized + IntoVisitor> DecodeAsType for T {
     fn decode_as_type_maybe_compact<R: TypeResolver>(
         input: &mut &[u8],
-        type_id: R::TypeId,
+        type_id: &R::TypeId,
         types: &R,
         is_compact: bool,
     ) -> Result<Self, Error> {

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -144,8 +144,8 @@ mod impls;
 pub mod error;
 pub mod visitor;
 
-use scale_type_resolver::{FieldIter, TypeResolver};
-
+pub use scale_type_resolver::FieldIter;
+pub use scale_type_resolver::TypeResolver;
 pub use crate::error::Error;
 pub use visitor::Visitor;
 pub use scale_type_resolver::Field;
@@ -158,6 +158,7 @@ pub use alloc::{collections::BTreeMap, string::ToString, vec};
 pub mod ext {
     #[cfg(feature = "primitive-types")]
     pub use primitive_types;
+    pub use scale_type_resolver;
 }
 
 /// This trait is implemented for any type `T` where `T` implements [`IntoVisitor`] and the errors returned

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -200,7 +200,7 @@ impl<T: Sized + IntoVisitor> DecodeAsType for T {
             input,
             type_id,
             types,
-            T::into_visitor(),
+            T::into_visitor::<R>(),
             is_compact,
         )?;
         Ok(res)
@@ -229,9 +229,9 @@ pub trait DecodeAsFields: Sized {
 // rather than rely on auto conversion, if they care about also being able to impl `DecodeAsType`.
 pub trait IntoVisitor {
     /// The visitor type used to decode SCALE encoded bytes to `Self`.
-    type Visitor: for<'scale, 'info> visitor::Visitor<Value<'scale, 'info> = Self, Error = Error>;
+    type AnyVisitor<R: TypeResolver>: for<'scale, 'info> visitor::Visitor<Value<'scale, 'info> = Self, Error = Error, TypeResolver = R>;
     /// A means of obtaining this visitor.
-    fn into_visitor() -> Self::Visitor;
+    fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R>;
 }
 
 /// The `DecodeAsType` derive macro can be used to implement `DecodeAsType` on structs and enums whose

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -55,7 +55,7 @@ fn get_type_info<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
     let mut types = scale_info::Registry::new();
     let ty = types.register_type(&m);
     let portable_registry: PortableRegistry = types.into();
-    (ty.id(), portable_registry)
+    (ty.id, portable_registry)
 }
 
 // Encode the left value statically.
@@ -68,7 +68,7 @@ where
 {
     let (type_id, types) = get_type_info::<A>();
     let a_bytes = a.encode();
-    let new_b = B::decode_as_type(&mut &*a_bytes, type_id, &types).unwrap();
+    let new_b = B::decode_as_type(&mut &*a_bytes, &type_id, &types).unwrap();
     assert_eq!(b, new_b);
 }
 
@@ -144,11 +144,11 @@ mod impls;
 pub mod error;
 pub mod visitor;
 
+pub use crate::error::Error;
+pub use scale_type_resolver::Field;
 pub use scale_type_resolver::FieldIter;
 pub use scale_type_resolver::TypeResolver;
-pub use crate::error::Error;
 pub use visitor::Visitor;
-pub use scale_type_resolver::Field;
 
 // This is exported for generated derive code to use, to be compatible with std or no-std as needed.
 #[doc(hidden)]
@@ -230,7 +230,11 @@ pub trait DecodeAsFields: Sized {
 // rather than rely on auto conversion, if they care about also being able to impl `DecodeAsType`.
 pub trait IntoVisitor {
     /// The visitor type used to decode SCALE encoded bytes to `Self`.
-    type AnyVisitor<R: TypeResolver>: for<'scale, 'info> visitor::Visitor<Value<'scale, 'info> = Self, Error = Error, TypeResolver = R>;
+    type AnyVisitor<R: TypeResolver>: for<'scale, 'info> visitor::Visitor<
+        Value<'scale, 'info> = Self,
+        Error = Error,
+        TypeResolver = R,
+    >;
     /// A means of obtaining this visitor.
     fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R>;
 }

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -14,16 +14,23 @@
 // limitations under the License.
 
 use crate::visitor::{
-    Array, BitSequence, Composite, DecodeAsTypeResult, DecodeError, Sequence, Str, Tuple, TypeId,
+    Array, BitSequence, Composite, DecodeAsTypeResult, DecodeError, Sequence, Str, Tuple,
     Variant, Visitor,
 };
 use crate::Field;
 use codec::{self, Decode};
-use scale_info::Type;
-use scale_info::{
-    form::PortableForm, Path, PortableRegistry, TypeDef, TypeDefArray, TypeDefBitSequence,
-    TypeDefComposite, TypeDefPrimitive, TypeDefSequence, TypeDefTuple, TypeDefVariant,
+use scale_type_resolver::{
+    BitsOrderFormat,
+    BitsStoreFormat,
+    Primitive,
+    TypeResolver,
+    ResolvedTypeVisitor,
+    FieldIter,
+    VariantIter
 };
+
+/// Return the type ID type of some [`Visitor`].
+type TypeIdFor<V: Visitor> = <V::TypeResolver as TypeResolver>::TypeId;
 
 /// Decode data according to the type ID and [`PortableRegistry`] provided.
 /// The provided pointer to the data slice will be moved forwards as needed
@@ -31,310 +38,299 @@ use scale_info::{
 /// will be called depending on the type that needs to be decoded.
 pub fn decode_with_visitor<'scale, 'info, V: Visitor>(
     data: &mut &'scale [u8],
-    ty_id: u32,
-    types: &'info PortableRegistry,
+    ty_id: TypeIdFor<V>,
+    types: &'info V::TypeResolver,
     visitor: V,
 ) -> Result<V::Value<'scale, 'info>, V::Error> {
     decode_with_visitor_maybe_compact(data, ty_id, types, visitor, false)
 }
 
-macro_rules! err_if_compact {
-    ($is_compact:expr, $ty:expr) => {
-        if $is_compact {
-            return Err(DecodeError::CannotDecodeCompactIntoType($ty.clone().into()).into());
-        }
-    };
-}
-
 pub fn decode_with_visitor_maybe_compact<'scale, 'info, V: Visitor>(
     data: &mut &'scale [u8],
-    ty_id: u32,
-    types: &'info PortableRegistry,
+    ty_id: TypeIdFor<V>,
+    types: &'info V::TypeResolver,
     visitor: V,
     is_compact: bool,
 ) -> Result<V::Value<'scale, 'info>, V::Error> {
     // Provide option to "bail out" and do something custom first.
-    let visitor = match visitor.unchecked_decode_as_type(data, TypeId(ty_id), types) {
+    let visitor = match visitor.unchecked_decode_as_type(data, ty_id, types) {
         DecodeAsTypeResult::Decoded(r) => return r,
         DecodeAsTypeResult::Skipped(v) => v,
     };
 
-    let ty = types.resolve(ty_id).ok_or(DecodeError::TypeIdNotFound(ty_id))?;
-    let ty_id = TypeId(ty_id);
-    let path = &ty.path;
+    let decoder = Decoder::new(data, types, visitor, is_compact);
+    let res = types.resolve_type(ty_id, decoder);
 
-    match &ty.type_def {
-        TypeDef::Composite(inner) => {
-            decode_composite_value(data, ty_id, path, inner, ty, types, visitor, is_compact)
-        }
-        TypeDef::Variant(inner) => {
-            err_if_compact!(is_compact, ty);
-            decode_variant_value(data, ty_id, path, inner, types, visitor)
-        }
-        TypeDef::Sequence(inner) => {
-            err_if_compact!(is_compact, ty);
-            decode_sequence_value(data, ty_id, inner, types, visitor)
-        }
-        TypeDef::Array(inner) => {
-            err_if_compact!(is_compact, ty);
-            decode_array_value(data, ty_id, inner, types, visitor)
-        }
-        TypeDef::Tuple(inner) => decode_tuple_value(data, ty_id, inner, types, visitor, is_compact),
-        TypeDef::Primitive(inner) => {
-            decode_primitive_value(data, ty_id, inner, visitor, is_compact)
-        }
-        TypeDef::Compact(inner) => {
-            decode_with_visitor_maybe_compact(data, inner.type_param.id, types, visitor, true)
-        }
-        TypeDef::BitSequence(inner) => {
-            err_if_compact!(is_compact, ty);
-            decode_bit_sequence_value(data, ty_id, inner, types, visitor)
-        }
+    match res {
+        // We got a value back; return it
+        Ok(Ok(val)) => Ok(val),
+        // We got a visitor error back; return it
+        Ok(Err(e)) => Err(e),
+        // We got a TypeResolver error back; turn it into a DecodeError and then visitor error to return.
+        Err(resolve_type_error) => Err(DecodeError::TypeResolvingError(resolve_type_error.to_string()).into()),
     }
 }
 
-/// Note: Only `U8`, `U16`, `U32`, `U64`, `U128` allow compact encoding and should be provided for the `compact_type` argument.
-#[allow(clippy::too_many_arguments)]
-fn decode_composite_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    path: &'info Path<PortableForm>,
-    ty: &'info TypeDefComposite<PortableForm>,
-    ty_super: &'info Type<PortableForm>,
-    types: &'info PortableRegistry,
+struct Decoder<'a, 'scale, 'info, V: Visitor> {
+    data: &'a mut &'scale [u8],
+    types: &'info V::TypeResolver,
     visitor: V,
     is_compact: bool,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    // guard against invalid compact types: only composites with 1 field can be compact encoded
-    if is_compact && ty.fields.len() != 1 {
-        return Err(DecodeError::CannotDecodeCompactIntoType(ty_super.clone()).into());
-    }
-
-    let mut fields = ty.fields.iter().map(|f| Field::new(f.ty.id, f.name.as_deref()));
-    let mut items = Composite::new(data, path, &mut fields, types, is_compact);
-    let res = visitor.visit_composite(&mut items, ty_id);
-
-    // Skip over any bytes that the visitor chose not to decode:
-    items.skip_decoding()?;
-    *data = items.bytes_from_undecoded();
-
-    res
 }
 
-fn decode_variant_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    path: &'info Path<PortableForm>,
-    ty: &'info TypeDefVariant<PortableForm>,
-    types: &'info PortableRegistry,
-    visitor: V,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    let mut variant = Variant::new(data, path, ty, types)?;
-    let res = visitor.visit_variant(&mut variant, ty_id);
-
-    // Skip over any bytes that the visitor chose not to decode:
-    variant.skip_decoding()?;
-    *data = variant.bytes_from_undecoded();
-
-    res
-}
-
-fn decode_sequence_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    ty: &'info TypeDefSequence<PortableForm>,
-    types: &'info PortableRegistry,
-    visitor: V,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    let mut items = Sequence::new(data, ty.type_param.id, types)?;
-    let res = visitor.visit_sequence(&mut items, ty_id);
-
-    // Skip over any bytes that the visitor chose not to decode:
-    items.skip_decoding()?;
-    *data = items.bytes_from_undecoded();
-
-    res
-}
-
-fn decode_array_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    ty: &'info TypeDefArray<PortableForm>,
-    types: &'info PortableRegistry,
-    visitor: V,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    let len = ty.len as usize;
-    let mut arr = Array::new(data, ty.type_param.id, len, types);
-    let res = visitor.visit_array(&mut arr, ty_id);
-
-    // Skip over any bytes that the visitor chose not to decode:
-    arr.skip_decoding()?;
-    *data = arr.bytes_from_undecoded();
-
-    res
-}
-
-fn decode_tuple_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    ty: &'info TypeDefTuple<PortableForm>,
-    types: &'info PortableRegistry,
-    visitor: V,
-    is_compact: bool,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    // guard against invalid compact types: only composites with 1 field can be compact encoded
-    if is_compact && ty.fields.len() != 1 {
-        return Err(DecodeError::CannotDecodeCompactIntoType(ty.clone().into()).into());
-    }
-
-    let mut fields = ty.fields.iter().map(|f| Field::unnamed(f.id));
-    let mut items = Tuple::new(data, &mut fields, types, is_compact);
-    let res = visitor.visit_tuple(&mut items, ty_id);
-
-    // Skip over any bytes that the visitor chose not to decode:
-    items.skip_decoding()?;
-    *data = items.bytes_from_undecoded();
-
-    res
-}
-
-fn decode_primitive_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    ty: &'info TypeDefPrimitive,
-    visitor: V,
-    is_compact: bool,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    fn decode_32_bytes<'scale>(data: &mut &'scale [u8]) -> Result<&'scale [u8; 32], DecodeError> {
-        // Pull an array from the data if we can, preserving the lifetime.
-        let arr: &'scale [u8; 32] = match (*data).try_into() {
-            Ok(arr) => arr,
-            Err(_) => return Err(DecodeError::NotEnoughInput),
-        };
-        // If this works out, remember to shift data 32 bytes forward.
-        *data = &data[32..];
-        Ok(arr)
-    }
-    match ty {
-        TypeDefPrimitive::Bool => {
-            err_if_compact!(is_compact, ty);
-            let b = bool::decode(data).map_err(|e| e.into())?;
-            visitor.visit_bool(b, ty_id)
-        }
-        TypeDefPrimitive::Char => {
-            err_if_compact!(is_compact, ty);
-            // Treat chars as u32's
-            let val = u32::decode(data).map_err(|e| e.into())?;
-            let c = char::from_u32(val).ok_or(DecodeError::InvalidChar(val))?;
-            visitor.visit_char(c, ty_id)
-        }
-        TypeDefPrimitive::Str => {
-            err_if_compact!(is_compact, ty);
-            // Avoid allocating; don't decode into a String. instead, pull the bytes
-            // and let the visitor decide whether to use them or not.
-            let mut s = Str::new(data)?;
-            // Since we aren't decoding here, shift our bytes along to after the str:
-            *data = s.bytes_after();
-            visitor.visit_str(&mut s, ty_id)
-        }
-        TypeDefPrimitive::U8 => {
-            let n = if is_compact {
-                codec::Compact::<u8>::decode(data).map(|c| c.0)
-            } else {
-                u8::decode(data)
-            }
-            .map_err(Into::into)?;
-            visitor.visit_u8(n, ty_id)
-        }
-        TypeDefPrimitive::U16 => {
-            let n = if is_compact {
-                codec::Compact::<u16>::decode(data).map(|c| c.0)
-            } else {
-                u16::decode(data)
-            }
-            .map_err(Into::into)?;
-            visitor.visit_u16(n, ty_id)
-        }
-        TypeDefPrimitive::U32 => {
-            let n = if is_compact {
-                codec::Compact::<u32>::decode(data).map(|c| c.0)
-            } else {
-                u32::decode(data)
-            }
-            .map_err(Into::into)?;
-            visitor.visit_u32(n, ty_id)
-        }
-        TypeDefPrimitive::U64 => {
-            let n = if is_compact {
-                codec::Compact::<u64>::decode(data).map(|c| c.0)
-            } else {
-                u64::decode(data)
-            }
-            .map_err(Into::into)?;
-            visitor.visit_u64(n, ty_id)
-        }
-        TypeDefPrimitive::U128 => {
-            let n = if is_compact {
-                codec::Compact::<u128>::decode(data).map(|c| c.0)
-            } else {
-                u128::decode(data)
-            }
-            .map_err(Into::into)?;
-            visitor.visit_u128(n, ty_id)
-        }
-        TypeDefPrimitive::U256 => {
-            err_if_compact!(is_compact, *ty);
-            let arr = decode_32_bytes(data)?;
-            visitor.visit_u256(arr, ty_id)
-        }
-        TypeDefPrimitive::I8 => {
-            err_if_compact!(is_compact, ty);
-            let n = i8::decode(data).map_err(|e| e.into())?;
-            visitor.visit_i8(n, ty_id)
-        }
-        TypeDefPrimitive::I16 => {
-            err_if_compact!(is_compact, ty);
-            let n = i16::decode(data).map_err(|e| e.into())?;
-            visitor.visit_i16(n, ty_id)
-        }
-        TypeDefPrimitive::I32 => {
-            err_if_compact!(is_compact, ty);
-            let n = i32::decode(data).map_err(|e| e.into())?;
-            visitor.visit_i32(n, ty_id)
-        }
-        TypeDefPrimitive::I64 => {
-            err_if_compact!(is_compact, ty);
-            let n = i64::decode(data).map_err(|e| e.into())?;
-            visitor.visit_i64(n, ty_id)
-        }
-        TypeDefPrimitive::I128 => {
-            err_if_compact!(is_compact, ty);
-            let n = i128::decode(data).map_err(|e| e.into())?;
-            visitor.visit_i128(n, ty_id)
-        }
-        TypeDefPrimitive::I256 => {
-            err_if_compact!(is_compact, ty);
-            let arr = decode_32_bytes(data)?;
-            visitor.visit_i256(arr, ty_id)
+impl <'a, 'scale, 'info, V: Visitor> Decoder<'a, 'scale, 'info, V> {
+    fn new(data: &'a mut &'scale [u8], types: &'info V::TypeResolver, visitor: V, is_compact: bool) -> Self {
+        Decoder {
+            data,
+            types,
+            is_compact,
+            visitor,
         }
     }
 }
 
-fn decode_bit_sequence_value<'scale, 'info, V: Visitor>(
-    data: &mut &'scale [u8],
-    ty_id: TypeId,
-    ty: &'info TypeDefBitSequence<PortableForm>,
-    types: &'info PortableRegistry,
-    visitor: V,
-) -> Result<V::Value<'scale, 'info>, V::Error> {
-    use scale_bits::Format;
+impl <'a, 'scale, 'info, V: Visitor> ResolvedTypeVisitor for Decoder<'a, 'scale, 'info, V> {
+    type TypeId = TypeIdFor<V>;
+    type Value<'info2> = Result<V::Value<'scale, 'info2>, V::Error>;
 
-    let format = Format::from_metadata(ty, types).map_err(DecodeError::BitSequenceError)?;
-    let mut bitseq = BitSequence::new(format, data);
-    let res = visitor.visit_bitsequence(&mut bitseq, ty_id);
+    fn visit_not_found<'info2>(self, type_id: Self::TypeId) -> Self::Value<'info2> {
+        Err(DecodeError::TypeIdNotFound(type_id))
+    }
 
-    // Move to the bytes after the bit sequence.
-    *data = bitseq.bytes_after()?;
+    fn visit_composite<'info2, Fields>(self, type_id: Self::TypeId, mut fields: Fields) -> Self::Value<'info2>
+    where
+        Fields: FieldIter<'info2, Self::TypeId>
+    {
+        // guard against invalid compact types: only composites with 1 field can be compact encoded
+        if self.is_compact && fields.len() != 1 {
+            return Err(DecodeError::CannotDecodeCompactIntoType.into());
+        }
 
-    res
+        // let mut fields = fields.map(|f| Field::new(f.ty.id, f.name.as_deref()));
+        let mut items = Composite::new(self.data, &mut fields, self.types, self.is_compact);
+        let res = self.visitor.visit_composite(&mut items, type_id);
+
+        // Skip over any bytes that the visitor chose not to decode:
+        items.skip_decoding()?;
+        *self.data = items.bytes_from_undecoded();
+
+        res
+    }
+
+    fn visit_variant<'info2, Fields, Var>(self, type_id: Self::TypeId, variants: Var) -> Self::Value<'info2>
+    where
+        Fields: FieldIter<'info2, Self::TypeId>,
+        Var: VariantIter<'info2, Fields>
+    {
+        if self.is_compact{
+            return Err(DecodeError::CannotDecodeCompactIntoType.into());
+        }
+
+        let mut variant = Variant::new(self.data, variants, self.types)?;
+        let res = self.visitor.visit_variant(&mut variant, type_id);
+
+        // Skip over any bytes that the visitor chose not to decode:
+        variant.skip_decoding()?;
+        *self.data = variant.bytes_from_undecoded();
+
+        res
+    }
+
+    fn visit_sequence<'info2>(self, type_id: Self::TypeId) -> Self::Value<'info2> {
+        if self.is_compact{
+            return Err(DecodeError::CannotDecodeCompactIntoType.into());
+        }
+
+        let mut items = Sequence::new(self.data, type_id.clone(), self.types)?;
+        let res = self.visitor.visit_sequence(&mut items, type_id);
+
+        // Skip over any bytes that the visitor chose not to decode:
+        items.skip_decoding()?;
+        *self.data = items.bytes_from_undecoded();
+
+        res
+    }
+
+    fn visit_array<'info2>(self, type_id: Self::TypeId, len: usize) -> Self::Value<'info2> {
+        if self.is_compact{
+            return Err(DecodeError::CannotDecodeCompactIntoType.into());
+        }
+
+        let mut arr = Array::new(self.data, type_id.clone(), len, self.types);
+        let res = self.visitor.visit_array(&mut arr, type_id);
+
+        // Skip over any bytes that the visitor chose not to decode:
+        arr.skip_decoding()?;
+        *self.data = arr.bytes_from_undecoded();
+
+        res
+    }
+
+    fn visit_tuple<'info2, TypeIds>(self, type_id: Self::TypeId, type_ids: TypeIds) -> Self::Value<'info2>
+    where
+        TypeIds: ExactSizeIterator<Item=Self::TypeId>
+    {
+        // guard against invalid compact types: only composites with 1 field can be compact encoded
+        if self.is_compact && type_ids.len() != 1 {
+            return Err(DecodeError::CannotDecodeCompactIntoType);
+        }
+
+        let mut fields = type_ids.iter().map(|id| Field::unnamed(id));
+        let mut items = Tuple::new(self.data, &mut fields, self.types, self.is_compact);
+        let res = self.visitor.visit_tuple(&mut items, type_id);
+
+        // Skip over any bytes that the visitor chose not to decode:
+        items.skip_decoding()?;
+        *self.data = items.bytes_from_undecoded();
+
+        res
+    }
+
+    fn visit_primitive<'info2>(self, type_id: Self::TypeId, primitive: Primitive) -> Self::Value<'info2> {
+        macro_rules! err_if_compact {
+            ($is_compact:expr) => {
+                if $is_compact {
+                    return Err(DecodeError::CannotDecodeCompactIntoType.into());
+                }
+            };
+        }
+
+        fn decode_32_bytes<'scale>(data: &mut &'scale [u8]) -> Result<&'scale [u8; 32], DecodeError> {
+            // Pull an array from the data if we can, preserving the lifetime.
+            let arr: &'scale [u8; 32] = match (*data).try_into() {
+                Ok(arr) => arr,
+                Err(_) => return Err(DecodeError::NotEnoughInput),
+            };
+            // If this works out, remember to shift data 32 bytes forward.
+            *data = &data[32..];
+            Ok(arr)
+        }
+
+        let data = self.data;
+        let is_compact = self.is_compact;
+        let visitor = self.visitor;
+
+        match primitive {
+            Primitive::Bool => {
+                err_if_compact!(self.is_compact);
+                let b = bool::decode(data).map_err(|e| e.into())?;
+                visitor.visit_bool(b, type_id)
+            }
+            Primitive::Char => {
+                err_if_compact!(self.is_compact);
+                // Treat chars as u32's
+                let val = u32::decode(data).map_err(|e| e.into())?;
+                let c = char::from_u32(val).ok_or(DecodeError::InvalidChar(val))?;
+                visitor.visit_char(c, type_id)
+            }
+            Primitive::Str => {
+                err_if_compact!(self.is_compact);
+                // Avoid allocating; don't decode into a String. instead, pull the bytes
+                // and let the visitor decide whether to use them or not.
+                let mut s = Str::new(data)?;
+                // Since we aren't decoding here, shift our bytes along to after the str:
+                *data = s.bytes_after();
+                visitor.visit_str(&mut s, type_id)
+            }
+            Primitive::U8 => {
+                let n = if self.is_compact {
+                    codec::Compact::<u8>::decode(data).map(|c| c.0)
+                } else {
+                    u8::decode(data)
+                }
+                .map_err(Into::into)?;
+                visitor.visit_u8(n, type_id)
+            }
+            Primitive::U16 => {
+                let n = if self.is_compact {
+                    codec::Compact::<u16>::decode(data).map(|c| c.0)
+                } else {
+                    u16::decode(data)
+                }
+                .map_err(Into::into)?;
+                visitor.visit_u16(n, type_id)
+            }
+            Primitive::U32 => {
+                let n = if self.is_compact {
+                    codec::Compact::<u32>::decode(data).map(|c| c.0)
+                } else {
+                    u32::decode(data)
+                }
+                .map_err(Into::into)?;
+                visitor.visit_u32(n, type_id)
+            }
+            Primitive::U64 => {
+                let n = if self.is_compact {
+                    codec::Compact::<u64>::decode(data).map(|c| c.0)
+                } else {
+                    u64::decode(data)
+                }
+                .map_err(Into::into)?;
+                visitor.visit_u64(n, type_id)
+            }
+            Primitive::U128 => {
+                let n = if self.is_compact {
+                    codec::Compact::<u128>::decode(data).map(|c| c.0)
+                } else {
+                    u128::decode(data)
+                }
+                .map_err(Into::into)?;
+                visitor.visit_u128(n, type_id)
+            }
+            Primitive::U256 => {
+                err_if_compact!(self.is_compact);
+                let arr = decode_32_bytes(data)?;
+                visitor.visit_u256(arr, type_id)
+            }
+            Primitive::I8 => {
+                err_if_compact!(self.is_compact);
+                let n = i8::decode(data).map_err(|e| e.into())?;
+                visitor.visit_i8(n, type_id)
+            }
+            Primitive::I16 => {
+                err_if_compact!(self.is_compact);
+                let n = i16::decode(data).map_err(|e| e.into())?;
+                visitor.visit_i16(n, type_id)
+            }
+            Primitive::I32 => {
+                err_if_compact!(self.is_compact);
+                let n = i32::decode(data).map_err(|e| e.into())?;
+                visitor.visit_i32(n, type_id)
+            }
+            Primitive::I64 => {
+                err_if_compact!(self.is_compact);
+                let n = i64::decode(data).map_err(|e| e.into())?;
+                visitor.visit_i64(n, type_id)
+            }
+            Primitive::I128 => {
+                err_if_compact!(self.is_compact);
+                let n = i128::decode(data).map_err(|e| e.into())?;
+                visitor.visit_i128(n, type_id)
+            }
+            Primitive::I256 => {
+                err_if_compact!(self.is_compact);
+                let arr = decode_32_bytes(data)?;
+                visitor.visit_i256(arr, type_id)
+            }
+        }
+    }
+
+    fn visit_compact<'info2>(self, type_id: Self::TypeId) -> Self::Value<'info2> {
+        decode_with_visitor_maybe_compact(self.data, type_id, self.types, self.visitor, true)
+    }
+
+    fn visit_bit_sequence<'info2>(self, type_id: Self::TypeId, store_format: BitsStoreFormat, order_format: BitsOrderFormat) -> Self::Value<'info2> {
+        if self.is_compact{
+            return Err(DecodeError::CannotDecodeCompactIntoType.into());
+        }
+
+        let format = scale_bits::Format::new(store_format, order_format);
+        let mut bitseq = BitSequence::new(format, self.data);
+        let res = self.visitor.visit_bitsequence(&mut bitseq, type_id);
+
+        // Move to the bytes after the bit sequence.
+        *self.data = bitseq.bytes_after()?;
+
+        res
+    }
 }

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -15,7 +15,7 @@
 
 use crate::visitor::{
     Array, BitSequence, Composite, DecodeAsTypeResult, DecodeError, Sequence, Str, Tuple,
-    Variant, Visitor,
+    Variant, Visitor, TypeIdFor
 };
 use crate::Field;
 use codec::{self, Decode};
@@ -29,9 +29,6 @@ use scale_type_resolver::{
     FieldIter,
     VariantIter
 };
-
-/// Return the type ID type of some [`Visitor`].
-type TypeIdFor<V> = <<V as Visitor>::TypeResolver as TypeResolver>::TypeId;
 
 /// Decode data according to the type ID and [`PortableRegistry`] provided.
 /// The provided pointer to the data slice will be moved forwards as needed

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -25,7 +25,7 @@ use scale_type_resolver::{
     UnhandledKind, VariantIter,
 };
 
-/// Decode data according to the type ID and [`PortableRegistry`] provided.
+/// Decode data according to the type ID and type resolver provided.
 /// The provided pointer to the data slice will be moved forwards as needed
 /// depending on what was decoded, and a method on the provided [`Visitor`]
 /// will be called depending on the type that needs to be decoded.

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -214,7 +214,7 @@ impl<'a, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 Ok(arr) => arr,
                 Err(_) => return Err(DecodeError::NotEnoughInput),
             };
-            // If this works out, remember to shift data 32 bytes forward.
+            // If we successfully read the bytes, then advance the pointer past them.
             *data = &data[32..];
             Ok(arr)
         }

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -12,12 +12,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::visitor::{
     Array, BitSequence, Composite, DecodeAsTypeResult, DecodeError, Sequence, Str, Tuple,
     TypeIdFor, Variant, Visitor,
 };
 use crate::Field;
+use alloc::format;
+use alloc::string::ToString;
 use codec::{self, Decode};
 use scale_type_resolver::{
     BitsOrderFormat, BitsStoreFormat, FieldIter, Primitive, ResolvedTypeVisitor, TypeResolver,

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -179,7 +179,7 @@ impl<'a, 'scale, 'info, V: Visitor> ResolvedTypeVisitor<'info> for Decoder<'a, '
             return Err(DecodeError::CannotDecodeCompactIntoType.into());
         }
 
-        let mut fields = type_ids.map(|id| Field::unnamed(id));
+        let mut fields = type_ids.map(Field::unnamed);
         let mut items = Tuple::new(self.data, &mut fields, self.types, self.is_compact);
         let res = self.visitor.visit_tuple(&mut items, self.type_id);
 

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -238,6 +238,9 @@ pub trait Visitor: Sized {
 /// An error decoding SCALE bytes.
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::From, derive_more::Display)]
 pub enum DecodeError {
+    /// Type ID was not found
+    #[display(fmt = "Could not find type with ID '{_0:?}'")]
+    TypeIdNotFound(String),
     /// A low level error trying to resolve a type.
     #[display(fmt = "Failed to resolve type: {_0}")]
     TypeResolvingError(String),
@@ -354,10 +357,6 @@ pub trait DecodeItemIterator<'scale, 'info, R: TypeResolver> {
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>>;
 }
 
-/// The ID of the type being decoded.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct TypeId(pub u32);
-
 /// A [`Visitor`] implementation that just ignores all of the bytes.
 pub struct IgnoreVisitor<R>(std::marker::PhantomData<R>);
 
@@ -413,8 +412,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::visitor::TypeId;
-
     use super::*;
     use alloc::borrow::ToOwned;
     use alloc::string::{String, ToString};
@@ -1065,7 +1062,7 @@ mod test {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                type_id: TypeId,
+                type_id: u32,
                 _types: &'info scale_info::PortableRegistry,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -363,14 +363,14 @@ pub trait DecodeItemIterator<'scale, 'info, R: TypeResolver> {
 /// A [`Visitor`] implementation that just ignores all of the bytes.
 pub struct IgnoreVisitor<R>(std::marker::PhantomData<R>);
 
-impl <R> IgnoreVisitor<R> {
+impl<R> IgnoreVisitor<R> {
     /// Construct a new [`IgnoreVisitor`].
     pub fn new() -> Self {
         IgnoreVisitor(std::marker::PhantomData)
     }
 }
 
-impl <R: TypeResolver> Visitor for IgnoreVisitor<R> {
+impl<R: TypeResolver> Visitor for IgnoreVisitor<R> {
     type Value<'scale, 'info> = ();
     type Error = DecodeError;
     type TypeResolver = R;
@@ -451,20 +451,20 @@ mod test {
     }
 
     struct ValueVisitor<R>(std::marker::PhantomData<R>);
-    impl <R> Clone for ValueVisitor<R> {
+    impl<R> Clone for ValueVisitor<R> {
         fn clone(&self) -> Self {
             Self(self.0)
         }
     }
-    impl <R> Copy for ValueVisitor<R> {}
+    impl<R> Copy for ValueVisitor<R> {}
 
-    impl <R> ValueVisitor<R> {
+    impl<R> ValueVisitor<R> {
         pub fn new() -> Self {
             Self(std::marker::PhantomData)
         }
     }
 
-    impl <R: TypeResolver> Visitor for ValueVisitor<R> {
+    impl<R: TypeResolver> Visitor for ValueVisitor<R> {
         type Value<'scale, 'info> = Value;
         type Error = DecodeError;
         type TypeResolver = R;

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -49,7 +49,7 @@ pub trait Visitor: Sized {
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         _input: &mut &'scale [u8],
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         _types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         DecodeAsTypeResult::Skipped(self)
@@ -69,7 +69,7 @@ pub trait Visitor: Sized {
     fn visit_bool<'scale, 'info>(
         self,
         _value: bool,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bool)
     }
@@ -77,7 +77,7 @@ pub trait Visitor: Sized {
     fn visit_char<'scale, 'info>(
         self,
         _value: char,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Char)
     }
@@ -85,7 +85,7 @@ pub trait Visitor: Sized {
     fn visit_u8<'scale, 'info>(
         self,
         _value: u8,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U8)
     }
@@ -93,7 +93,7 @@ pub trait Visitor: Sized {
     fn visit_u16<'scale, 'info>(
         self,
         _value: u16,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U16)
     }
@@ -101,7 +101,7 @@ pub trait Visitor: Sized {
     fn visit_u32<'scale, 'info>(
         self,
         _value: u32,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U32)
     }
@@ -109,7 +109,7 @@ pub trait Visitor: Sized {
     fn visit_u64<'scale, 'info>(
         self,
         _value: u64,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U64)
     }
@@ -117,23 +117,23 @@ pub trait Visitor: Sized {
     fn visit_u128<'scale, 'info>(
         self,
         _value: u128,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U128)
     }
     /// Called when a u256 is seen in the input bytes.
-    fn visit_u256<'info>(
+    fn visit_u256<'scale, 'info>(
         self,
-        _value: &'_ [u8; 32],
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        _value: &'scale [u8; 32],
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U256)
     }
     /// Called when an i8 is seen in the input bytes.
     fn visit_i8<'scale, 'info>(
         self,
         _value: i8,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I8)
     }
@@ -141,7 +141,7 @@ pub trait Visitor: Sized {
     fn visit_i16<'scale, 'info>(
         self,
         _value: i16,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I16)
     }
@@ -149,7 +149,7 @@ pub trait Visitor: Sized {
     fn visit_i32<'scale, 'info>(
         self,
         _value: i32,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I32)
     }
@@ -157,7 +157,7 @@ pub trait Visitor: Sized {
     fn visit_i64<'scale, 'info>(
         self,
         _value: i64,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I64)
     }
@@ -165,23 +165,23 @@ pub trait Visitor: Sized {
     fn visit_i128<'scale, 'info>(
         self,
         _value: i128,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I128)
     }
     /// Called when an i256 is seen in the input bytes.
-    fn visit_i256<'info>(
+    fn visit_i256<'scale, 'info>(
         self,
-        _value: &'_ [u8; 32],
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        _value: &'scale [u8; 32],
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I256)
     }
     /// Called when a sequence of values is seen in the input bytes.
     fn visit_sequence<'scale, 'info>(
         self,
         _value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Sequence)
     }
@@ -189,7 +189,7 @@ pub trait Visitor: Sized {
     fn visit_composite<'scale, 'info>(
         self,
         _value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Composite)
     }
@@ -197,7 +197,7 @@ pub trait Visitor: Sized {
     fn visit_tuple<'scale, 'info>(
         self,
         _value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Tuple)
     }
@@ -205,7 +205,7 @@ pub trait Visitor: Sized {
     fn visit_str<'scale, 'info>(
         self,
         _value: &mut Str<'scale>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Str)
     }
@@ -213,7 +213,7 @@ pub trait Visitor: Sized {
     fn visit_variant<'scale, 'info>(
         self,
         _value: &mut Variant<'scale, 'info, Self::TypeResolver>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Variant)
     }
@@ -221,7 +221,7 @@ pub trait Visitor: Sized {
     fn visit_array<'scale, 'info>(
         self,
         _value: &mut Array<'scale, 'info, Self::TypeResolver>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Array)
     }
@@ -229,7 +229,7 @@ pub trait Visitor: Sized {
     fn visit_bitsequence<'scale, 'info>(
         self,
         _value: &mut BitSequence<'scale>,
-        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bitsequence)
     }
@@ -402,7 +402,7 @@ where
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         let res = decode_with_visitor(input, type_id, types, self.0).map_err(Into::into);
@@ -464,105 +464,105 @@ mod test {
         fn visit_bool<'scale, 'info>(
             self,
             value: bool,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Bool(value))
         }
         fn visit_char<'scale, 'info>(
             self,
             value: char,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Char(value))
         }
         fn visit_u8<'scale, 'info>(
             self,
             value: u8,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U8(value))
         }
         fn visit_u16<'scale, 'info>(
             self,
             value: u16,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U16(value))
         }
         fn visit_u32<'scale, 'info>(
             self,
             value: u32,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U32(value))
         }
         fn visit_u64<'scale, 'info>(
             self,
             value: u64,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U64(value))
         }
         fn visit_u128<'scale, 'info>(
             self,
             value: u128,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U128(value))
         }
-        fn visit_u256<'info>(
+        fn visit_u256<'scale, 'info>(
             self,
-            value: &'_ [u8; 32],
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
-        ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+            value: &'scale [u8; 32],
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U256(*value))
         }
         fn visit_i8<'scale, 'info>(
             self,
             value: i8,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I8(value))
         }
         fn visit_i16<'scale, 'info>(
             self,
             value: i16,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I16(value))
         }
         fn visit_i32<'scale, 'info>(
             self,
             value: i32,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I32(value))
         }
         fn visit_i64<'scale, 'info>(
             self,
             value: i64,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I64(value))
         }
         fn visit_i128<'scale, 'info>(
             self,
             value: i128,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I128(value))
         }
-        fn visit_i256<'info>(
+        fn visit_i256<'scale, 'info>(
             self,
-            value: &'_ [u8; 32],
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
-        ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+            value: &'scale [u8; 32],
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I256(*value))
         }
         fn visit_sequence<'scale, 'info>(
             self,
             value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -574,7 +574,7 @@ mod test {
         fn visit_composite<'scale, 'info>(
             self,
             value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             for item in value.by_ref() {
@@ -588,7 +588,7 @@ mod test {
         fn visit_tuple<'scale, 'info>(
             self,
             value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -600,14 +600,14 @@ mod test {
         fn visit_str<'scale, 'info>(
             self,
             value: &mut Str<'scale>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
         fn visit_variant<'scale, 'info>(
             self,
             value: &mut Variant<'scale, 'info, Self::TypeResolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             let fields = value.fields();
@@ -622,7 +622,7 @@ mod test {
         fn visit_array<'scale, 'info>(
             self,
             value: &mut Array<'scale, 'info, Self::TypeResolver>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -634,7 +634,7 @@ mod test {
         fn visit_bitsequence<'scale, 'info>(
             self,
             value: &mut BitSequence<'scale>,
-            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
             Ok(Value::BitSequence(bools?))
@@ -956,7 +956,7 @@ mod test {
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -972,7 +972,7 @@ mod test {
             fn visit_tuple<'scale, 'info>(
                 self,
                 value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let fst = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
                 let snd = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
@@ -982,7 +982,7 @@ mod test {
 
         let (ty_id, types) = make_type::<(&str, &str)>();
         let decoded =
-            decode_with_visitor(&mut &*input_encoded, ty_id, &types, ZeroCopyPairVisitor).unwrap();
+            decode_with_visitor(&mut &*input_encoded, &ty_id, &types, ZeroCopyPairVisitor).unwrap();
         assert_eq!(decoded, ("hello", "world"));
     }
 
@@ -1009,7 +1009,7 @@ mod test {
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -1025,7 +1025,7 @@ mod test {
             fn visit_composite<'scale, 'info>(
                 self,
                 value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let mut vals = alloc::collections::BTreeMap::<&'info str, &'scale str>::new();
                 for item in value {
@@ -1041,7 +1041,7 @@ mod test {
         // Decode and check:
         let (ty_id, types) = make_type::<Foo>();
         let decoded =
-            decode_with_visitor(&mut &*input_encoded, ty_id, &types, ZeroCopyMapVisitor).unwrap();
+            decode_with_visitor(&mut &*input_encoded, &ty_id, &types, ZeroCopyMapVisitor).unwrap();
         assert_eq!(decoded, BTreeMap::from_iter([("hello", "hi"), ("world", "planet")]));
     }
 
@@ -1071,7 +1071,7 @@ mod test {
         }
 
         let decoded =
-            decode_with_visitor(&mut &*input_encoded, ty_id, &types, BailOutVisitor).unwrap();
+            decode_with_visitor(&mut &*input_encoded, &ty_id, &types, BailOutVisitor).unwrap();
         assert_eq!(decoded, (&*input_encoded, ty_id));
 
         // We can also use this functionality to "fall-back" to a Decode impl
@@ -1085,7 +1085,7 @@ mod test {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
                 _types: &'info scale_info::PortableRegistry,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {
@@ -1095,7 +1095,7 @@ mod test {
 
         let decoded: (String, String) = decode_with_visitor(
             &mut &*input_encoded,
-            ty_id,
+            &ty_id,
             &types,
             CodecDecodeVisitor(core::marker::PhantomData),
         )

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -24,6 +24,9 @@ use types::*;
 pub use decode::decode_with_visitor;
 pub(crate) use decode::decode_with_visitor_maybe_compact;
 
+/// Return the type ID type of some [`Visitor`].
+pub type TypeIdFor<V> = <<V as Visitor>::TypeResolver as TypeResolver>::TypeId;
+
 /// An implementation of the [`Visitor`] trait can be passed to the [`decode_with_visitor()`]
 /// function, and is handed back values as they are encountered. It's up to the implementation
 /// to decide what to do with these values.
@@ -49,7 +52,7 @@ pub trait Visitor: Sized {
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         _input: &mut &'scale [u8],
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
         _types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         DecodeAsTypeResult::Skipped(self)
@@ -69,7 +72,7 @@ pub trait Visitor: Sized {
     fn visit_bool<'scale, 'info>(
         self,
         _value: bool,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bool)
     }
@@ -77,7 +80,7 @@ pub trait Visitor: Sized {
     fn visit_char<'scale, 'info>(
         self,
         _value: char,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Char)
     }
@@ -85,7 +88,7 @@ pub trait Visitor: Sized {
     fn visit_u8<'scale, 'info>(
         self,
         _value: u8,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U8)
     }
@@ -93,7 +96,7 @@ pub trait Visitor: Sized {
     fn visit_u16<'scale, 'info>(
         self,
         _value: u16,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U16)
     }
@@ -101,7 +104,7 @@ pub trait Visitor: Sized {
     fn visit_u32<'scale, 'info>(
         self,
         _value: u32,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U32)
     }
@@ -109,7 +112,7 @@ pub trait Visitor: Sized {
     fn visit_u64<'scale, 'info>(
         self,
         _value: u64,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U64)
     }
@@ -117,7 +120,7 @@ pub trait Visitor: Sized {
     fn visit_u128<'scale, 'info>(
         self,
         _value: u128,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U128)
     }
@@ -125,7 +128,7 @@ pub trait Visitor: Sized {
     fn visit_u256<'scale, 'info>(
         self,
         _value: &'scale [u8; 32],
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U256)
     }
@@ -133,7 +136,7 @@ pub trait Visitor: Sized {
     fn visit_i8<'scale, 'info>(
         self,
         _value: i8,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I8)
     }
@@ -141,7 +144,7 @@ pub trait Visitor: Sized {
     fn visit_i16<'scale, 'info>(
         self,
         _value: i16,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I16)
     }
@@ -149,7 +152,7 @@ pub trait Visitor: Sized {
     fn visit_i32<'scale, 'info>(
         self,
         _value: i32,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I32)
     }
@@ -157,7 +160,7 @@ pub trait Visitor: Sized {
     fn visit_i64<'scale, 'info>(
         self,
         _value: i64,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I64)
     }
@@ -165,7 +168,7 @@ pub trait Visitor: Sized {
     fn visit_i128<'scale, 'info>(
         self,
         _value: i128,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I128)
     }
@@ -173,7 +176,7 @@ pub trait Visitor: Sized {
     fn visit_i256<'scale, 'info>(
         self,
         _value: &'scale [u8; 32],
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I256)
     }
@@ -181,7 +184,7 @@ pub trait Visitor: Sized {
     fn visit_sequence<'scale, 'info>(
         self,
         _value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Sequence)
     }
@@ -189,7 +192,7 @@ pub trait Visitor: Sized {
     fn visit_composite<'scale, 'info>(
         self,
         _value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Composite)
     }
@@ -197,7 +200,7 @@ pub trait Visitor: Sized {
     fn visit_tuple<'scale, 'info>(
         self,
         _value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Tuple)
     }
@@ -205,7 +208,7 @@ pub trait Visitor: Sized {
     fn visit_str<'scale, 'info>(
         self,
         _value: &mut Str<'scale>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Str)
     }
@@ -213,7 +216,7 @@ pub trait Visitor: Sized {
     fn visit_variant<'scale, 'info>(
         self,
         _value: &mut Variant<'scale, 'info, Self::TypeResolver>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Variant)
     }
@@ -221,7 +224,7 @@ pub trait Visitor: Sized {
     fn visit_array<'scale, 'info>(
         self,
         _value: &mut Array<'scale, 'info, Self::TypeResolver>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Array)
     }
@@ -229,7 +232,7 @@ pub trait Visitor: Sized {
     fn visit_bitsequence<'scale, 'info>(
         self,
         _value: &mut BitSequence<'scale>,
-        _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        _type_id: &TypeIdFor<Self>,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bitsequence)
     }
@@ -402,7 +405,7 @@ where
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+        type_id: &TypeIdFor<Self>,
         types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         let res = decode_with_visitor(input, type_id, types, self.0).map_err(Into::into);
@@ -447,8 +450,13 @@ mod test {
         BitSequence(scale_bits::Bits),
     }
 
-    #[derive(Clone, Copy)]
     struct ValueVisitor<R>(std::marker::PhantomData<R>);
+    impl <R> Clone for ValueVisitor<R> {
+        fn clone(&self) -> Self {
+            Self(self.0)
+        }
+    }
+    impl <R> Copy for ValueVisitor<R> {}
 
     impl <R> ValueVisitor<R> {
         pub fn new() -> Self {
@@ -464,108 +472,108 @@ mod test {
         fn visit_bool<'scale, 'info>(
             self,
             value: bool,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Bool(value))
         }
         fn visit_char<'scale, 'info>(
             self,
             value: char,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Char(value))
         }
         fn visit_u8<'scale, 'info>(
             self,
             value: u8,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U8(value))
         }
         fn visit_u16<'scale, 'info>(
             self,
             value: u16,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U16(value))
         }
         fn visit_u32<'scale, 'info>(
             self,
             value: u32,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U32(value))
         }
         fn visit_u64<'scale, 'info>(
             self,
             value: u64,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U64(value))
         }
         fn visit_u128<'scale, 'info>(
             self,
             value: u128,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U128(value))
         }
         fn visit_u256<'scale, 'info>(
             self,
             value: &'scale [u8; 32],
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U256(*value))
         }
         fn visit_i8<'scale, 'info>(
             self,
             value: i8,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I8(value))
         }
         fn visit_i16<'scale, 'info>(
             self,
             value: i16,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I16(value))
         }
         fn visit_i32<'scale, 'info>(
             self,
             value: i32,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I32(value))
         }
         fn visit_i64<'scale, 'info>(
             self,
             value: i64,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I64(value))
         }
         fn visit_i128<'scale, 'info>(
             self,
             value: i128,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I128(value))
         }
         fn visit_i256<'scale, 'info>(
             self,
             value: &'scale [u8; 32],
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I256(*value))
         }
         fn visit_sequence<'scale, 'info>(
             self,
             value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
-            while let Some(val) = value.decode_item(ValueVisitor) {
+            while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
                 vals.push(val);
             }
@@ -574,12 +582,12 @@ mod test {
         fn visit_composite<'scale, 'info>(
             self,
             value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             for item in value.by_ref() {
                 let item = item?;
-                let val = item.decode_with_visitor(ValueVisitor)?;
+                let val = item.decode_with_visitor(ValueVisitor::new())?;
                 let name = item.name().unwrap_or("").to_owned();
                 vals.push((name, val));
             }
@@ -588,10 +596,10 @@ mod test {
         fn visit_tuple<'scale, 'info>(
             self,
             value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
-            while let Some(val) = value.decode_item(ValueVisitor) {
+            while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
                 vals.push(val);
             }
@@ -600,20 +608,20 @@ mod test {
         fn visit_str<'scale, 'info>(
             self,
             value: &mut Str<'scale>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
         fn visit_variant<'scale, 'info>(
             self,
             value: &mut Variant<'scale, 'info, Self::TypeResolver>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             let fields = value.fields();
             for item in fields.by_ref() {
                 let item = item?;
-                let val = item.decode_with_visitor(ValueVisitor)?;
+                let val = item.decode_with_visitor(ValueVisitor::new())?;
                 let name = item.name().unwrap_or("").to_owned();
                 vals.push((name, val));
             }
@@ -622,10 +630,10 @@ mod test {
         fn visit_array<'scale, 'info>(
             self,
             value: &mut Array<'scale, 'info, Self::TypeResolver>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
-            while let Some(val) = value.decode_item(ValueVisitor) {
+            while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
                 vals.push(val);
             }
@@ -634,7 +642,7 @@ mod test {
         fn visit_bitsequence<'scale, 'info>(
             self,
             value: &mut BitSequence<'scale>,
-            _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+            _type_id: &TypeIdFor<Self>,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
             Ok(Value::BitSequence(bools?))
@@ -657,7 +665,7 @@ mod test {
     fn encode_decode_check_explicit_info<
         Ty: scale_info::TypeInfo + 'static,
         T: Encode,
-        V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E>,
+        V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E, TypeResolver = PortableRegistry>,
         E: core::fmt::Debug,
     >(
         val: T,
@@ -668,7 +676,7 @@ mod test {
         let (id, types) = make_type::<Ty>();
         let bytes = &mut &*encoded;
         let val =
-            decode_with_visitor(bytes, id, &types, visitor).expect("decoding should not error");
+            decode_with_visitor(bytes, &id, &types, visitor).expect("decoding should not error");
 
         assert_eq!(bytes.len(), 0, "Decoding should consume all bytes");
         assert_eq!(val, expected);
@@ -676,7 +684,7 @@ mod test {
 
     fn encode_decode_check_with_visitor<
         T: Encode + scale_info::TypeInfo + 'static,
-        V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E>,
+        V: for<'s, 'i> Visitor<Value<'s, 'i> = Value, Error = E, TypeResolver = PortableRegistry>,
         E: core::fmt::Debug,
     >(
         val: T,
@@ -687,13 +695,13 @@ mod test {
     }
 
     fn encode_decode_check<T: Encode + scale_info::TypeInfo + 'static>(val: T, expected: Value) {
-        encode_decode_check_explicit_info::<T, T, _, _>(val, expected, ValueVisitor);
+        encode_decode_check_explicit_info::<T, T, _, _>(val, expected, ValueVisitor::new());
     }
 
     #[test]
     fn decode_with_root_error_wrapper_works() {
         use crate::visitor::VisitorWithCrateError;
-        let visitor = VisitorWithCrateError(ValueVisitor);
+        let visitor = VisitorWithCrateError(ValueVisitor::new());
 
         encode_decode_check_with_visitor(123u8, Value::U8(123), visitor);
         encode_decode_check_with_visitor(123u16, Value::U16(123), visitor);
@@ -736,7 +744,7 @@ mod test {
         encode_decode_check_explicit_info::<char, _, _, _>(
             'c' as u32,
             Value::Char('c'),
-            ValueVisitor,
+            ValueVisitor::new(),
         );
         encode_decode_check("Hello there", Value::Str("Hello there".to_owned()));
         encode_decode_check("Hello there".to_string(), Value::Str("Hello there".to_owned()));
@@ -956,7 +964,7 @@ mod test {
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &TypeIdFor<Self>,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -972,7 +980,7 @@ mod test {
             fn visit_tuple<'scale, 'info>(
                 self,
                 value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
-                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &TypeIdFor<Self>,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let fst = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
                 let snd = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
@@ -1009,7 +1017,7 @@ mod test {
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &TypeIdFor<Self>,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -1025,7 +1033,7 @@ mod test {
             fn visit_composite<'scale, 'info>(
                 self,
                 value: &mut Composite<'scale, 'info, Self::TypeResolver>,
-                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &TypeIdFor<Self>,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let mut vals = alloc::collections::BTreeMap::<&'info str, &'scale str>::new();
                 for item in value {
@@ -1062,11 +1070,11 @@ mod test {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                type_id: u32,
+                type_id: &u32,
                 _types: &'info scale_info::PortableRegistry,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {
-                DecodeAsTypeResult::Decoded(Ok((*input, type_id.0)))
+                DecodeAsTypeResult::Decoded(Ok((*input, *type_id)))
             }
         }
 
@@ -1085,7 +1093,7 @@ mod test {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                _type_id: &<Self::TypeResolver as TypeResolver>::TypeId,
+                _type_id: &TypeIdFor<Self>,
                 _types: &'info scale_info::PortableRegistry,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -18,7 +18,7 @@
 mod decode;
 pub mod types;
 
-use scale_info::form::PortableForm;
+use scale_type_resolver::TypeResolver;
 use types::*;
 
 pub use decode::decode_with_visitor;
@@ -33,6 +33,8 @@ pub trait Visitor: Sized {
     /// The error type (which we must be able to convert a combination of [`Self`] and [`DecodeError`]s
     /// into, to handle any internal errors that crop up trying to decode things).
     type Error: From<DecodeError>;
+    /// The thing we'll use to resolve type IDs into concrete types.
+    type TypeResolver: TypeResolver;
 
     /// This method is called immediately upon running [`decode_with_visitor()`]. By default we ignore
     /// this call and return our visitor back (ie [`DecodeAsTypeResult::Skipped(visitor)`]). If you choose to
@@ -47,8 +49,8 @@ pub trait Visitor: Sized {
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         _input: &mut &'scale [u8],
-        _type_id: TypeId,
-        _types: &'info scale_info::PortableRegistry,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        _types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         DecodeAsTypeResult::Skipped(self)
     }
@@ -67,7 +69,7 @@ pub trait Visitor: Sized {
     fn visit_bool<'scale, 'info>(
         self,
         _value: bool,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bool)
     }
@@ -75,7 +77,7 @@ pub trait Visitor: Sized {
     fn visit_char<'scale, 'info>(
         self,
         _value: char,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Char)
     }
@@ -83,7 +85,7 @@ pub trait Visitor: Sized {
     fn visit_u8<'scale, 'info>(
         self,
         _value: u8,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U8)
     }
@@ -91,7 +93,7 @@ pub trait Visitor: Sized {
     fn visit_u16<'scale, 'info>(
         self,
         _value: u16,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U16)
     }
@@ -99,7 +101,7 @@ pub trait Visitor: Sized {
     fn visit_u32<'scale, 'info>(
         self,
         _value: u32,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U32)
     }
@@ -107,7 +109,7 @@ pub trait Visitor: Sized {
     fn visit_u64<'scale, 'info>(
         self,
         _value: u64,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U64)
     }
@@ -115,7 +117,7 @@ pub trait Visitor: Sized {
     fn visit_u128<'scale, 'info>(
         self,
         _value: u128,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U128)
     }
@@ -123,7 +125,7 @@ pub trait Visitor: Sized {
     fn visit_u256<'info>(
         self,
         _value: &'_ [u8; 32],
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'_, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::U256)
     }
@@ -131,7 +133,7 @@ pub trait Visitor: Sized {
     fn visit_i8<'scale, 'info>(
         self,
         _value: i8,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I8)
     }
@@ -139,7 +141,7 @@ pub trait Visitor: Sized {
     fn visit_i16<'scale, 'info>(
         self,
         _value: i16,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I16)
     }
@@ -147,7 +149,7 @@ pub trait Visitor: Sized {
     fn visit_i32<'scale, 'info>(
         self,
         _value: i32,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I32)
     }
@@ -155,7 +157,7 @@ pub trait Visitor: Sized {
     fn visit_i64<'scale, 'info>(
         self,
         _value: i64,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I64)
     }
@@ -163,7 +165,7 @@ pub trait Visitor: Sized {
     fn visit_i128<'scale, 'info>(
         self,
         _value: i128,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I128)
     }
@@ -171,31 +173,31 @@ pub trait Visitor: Sized {
     fn visit_i256<'info>(
         self,
         _value: &'_ [u8; 32],
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'_, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::I256)
     }
     /// Called when a sequence of values is seen in the input bytes.
     fn visit_sequence<'scale, 'info>(
         self,
-        _value: &mut Sequence<'scale, 'info>,
-        _type_id: TypeId,
+        _value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Sequence)
     }
     /// Called when a composite value is seen in the input bytes.
     fn visit_composite<'scale, 'info>(
         self,
-        _value: &mut Composite<'scale, 'info>,
-        _type_id: TypeId,
+        _value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Composite)
     }
     /// Called when a tuple of values is seen in the input bytes.
     fn visit_tuple<'scale, 'info>(
         self,
-        _value: &mut Tuple<'scale, 'info>,
-        _type_id: TypeId,
+        _value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Tuple)
     }
@@ -203,23 +205,23 @@ pub trait Visitor: Sized {
     fn visit_str<'scale, 'info>(
         self,
         _value: &mut Str<'scale>,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Str)
     }
     /// Called when a variant is seen in the input bytes.
     fn visit_variant<'scale, 'info>(
         self,
-        _value: &mut Variant<'scale, 'info>,
-        _type_id: TypeId,
+        _value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Variant)
     }
     /// Called when an array is seen in the input bytes.
     fn visit_array<'scale, 'info>(
         self,
-        _value: &mut Array<'scale, 'info>,
-        _type_id: TypeId,
+        _value: &mut Array<'scale, 'info, Self::TypeResolver>,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Array)
     }
@@ -227,7 +229,7 @@ pub trait Visitor: Sized {
     fn visit_bitsequence<'scale, 'info>(
         self,
         _value: &mut BitSequence<'scale>,
-        _type_id: TypeId,
+        _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         self.visit_unexpected(Unexpected::Bitsequence)
     }
@@ -236,13 +238,12 @@ pub trait Visitor: Sized {
 /// An error decoding SCALE bytes.
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::From, derive_more::Display)]
 pub enum DecodeError {
-    /// We ran into an error trying to decode a bit sequence.
-    #[from]
-    #[display(fmt = "Cannot decode bit sequence: {_0}")]
-    BitSequenceError(BitSequenceError),
+    /// A low level error trying to resolve a type.
+    #[display(fmt = "Failed to resolve type: {_0}")]
+    TypeResolvingError(String),
     /// The type we're trying to decode is supposed to be compact encoded, but that is not possible.
-    #[display(fmt = "Could not decode compact encoded type into {_0:?}")]
-    CannotDecodeCompactIntoType(scale_info::Type<PortableForm>),
+    #[display(fmt = "Could not decode compact encoded type: compact types can only have 1 field")]
+    CannotDecodeCompactIntoType,
     /// Failure to decode bytes into a string.
     #[from]
     #[display(fmt = "Could not decode string: {_0}")]
@@ -254,14 +255,11 @@ pub enum DecodeError {
     #[display(fmt = "Ran out of data during decoding")]
     NotEnoughInput,
     /// We found a variant that does not match with any in the type we're trying to decode from.
-    #[display(fmt = "Could not find variant with index {_0} in {_1:?}")]
-    VariantNotFound(u8, scale_info::TypeDefVariant<PortableForm>),
+    #[display(fmt = "Could not find variant with index {_0}")]
+    VariantNotFound(u8),
     /// Some error emitted from a [`codec::Decode`] impl.
     #[from]
     CodecError(codec::Error),
-    /// We could not find the type given in the type registry provided.
-    #[display(fmt = "Cannot find type with ID {_0}")]
-    TypeIdNotFound(u32),
     /// This is returned by default if a visitor function is not implemented.
     #[display(fmt = "Unexpected type {_0}")]
     Unexpected(Unexpected),
@@ -348,26 +346,32 @@ impl<V, R> DecodeAsTypeResult<V, R> {
 
 /// This is implemented for visitor related types which have a `decode_item` method,
 /// and allows you to generically talk about decoding unnamed items.
-pub trait DecodeItemIterator<'scale, 'info> {
+pub trait DecodeItemIterator<'scale, 'info, R: TypeResolver> {
     /// Use a visitor to decode a single item.
-    fn decode_item<V: Visitor>(
+    fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>>;
 }
-
-/// An error that can occur trying to decode a bit sequence.
-pub type BitSequenceError = scale_bits::scale::format::FromMetadataError;
 
 /// The ID of the type being decoded.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TypeId(pub u32);
 
 /// A [`Visitor`] implementation that just ignores all of the bytes.
-pub struct IgnoreVisitor;
-impl Visitor for IgnoreVisitor {
+pub struct IgnoreVisitor<R>(std::marker::PhantomData<R>);
+
+impl <R> IgnoreVisitor<R> {
+    /// Construct a new [`IgnoreVisitor`].
+    pub fn new() -> Self {
+        IgnoreVisitor(std::marker::PhantomData)
+    }
+}
+
+impl <R: TypeResolver> Visitor for IgnoreVisitor<R> {
     type Value<'scale, 'info> = ();
     type Error = DecodeError;
+    type TypeResolver = R;
 
     // Whatever the value we visit is, just ignore it.
     fn visit_unexpected<'scale, 'info>(
@@ -394,14 +398,15 @@ where
 {
     type Value<'scale, 'info> = V::Value<'scale, 'info>;
     type Error = crate::Error;
+    type TypeResolver = V::TypeResolver;
 
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: TypeId,
-        types: &'info scale_info::PortableRegistry,
+        type_id: <Self::TypeResolver as TypeResolver>::TypeId,
+        types: &'info Self::TypeResolver,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
-        let res = decode_with_visitor(input, type_id.0, types, self.0).map_err(Into::into);
+        let res = decode_with_visitor(input, type_id, types, self.0).map_err(Into::into);
         DecodeAsTypeResult::Decoded(res)
     }
 }
@@ -446,113 +451,121 @@ mod test {
     }
 
     #[derive(Clone, Copy)]
-    struct ValueVisitor;
-    impl Visitor for ValueVisitor {
+    struct ValueVisitor<R>(std::marker::PhantomData<R>);
+
+    impl <R> ValueVisitor<R> {
+        pub fn new() -> Self {
+            Self(std::marker::PhantomData)
+        }
+    }
+
+    impl <R: TypeResolver> Visitor for ValueVisitor<R> {
         type Value<'scale, 'info> = Value;
         type Error = DecodeError;
+        type TypeResolver = R;
 
         fn visit_bool<'scale, 'info>(
             self,
             value: bool,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Bool(value))
         }
         fn visit_char<'scale, 'info>(
             self,
             value: char,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Char(value))
         }
         fn visit_u8<'scale, 'info>(
             self,
             value: u8,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U8(value))
         }
         fn visit_u16<'scale, 'info>(
             self,
             value: u16,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U16(value))
         }
         fn visit_u32<'scale, 'info>(
             self,
             value: u32,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U32(value))
         }
         fn visit_u64<'scale, 'info>(
             self,
             value: u64,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U64(value))
         }
         fn visit_u128<'scale, 'info>(
             self,
             value: u128,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::U128(value))
         }
         fn visit_u256<'info>(
             self,
             value: &'_ [u8; 32],
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'_, 'info>, Self::Error> {
             Ok(Value::U256(*value))
         }
         fn visit_i8<'scale, 'info>(
             self,
             value: i8,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I8(value))
         }
         fn visit_i16<'scale, 'info>(
             self,
             value: i16,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I16(value))
         }
         fn visit_i32<'scale, 'info>(
             self,
             value: i32,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I32(value))
         }
         fn visit_i64<'scale, 'info>(
             self,
             value: i64,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I64(value))
         }
         fn visit_i128<'scale, 'info>(
             self,
             value: i128,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::I128(value))
         }
         fn visit_i256<'info>(
             self,
             value: &'_ [u8; 32],
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'_, 'info>, Self::Error> {
             Ok(Value::I256(*value))
         }
         fn visit_sequence<'scale, 'info>(
             self,
-            value: &mut Sequence<'scale, 'info>,
-            _type_id: TypeId,
+            value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -563,8 +576,8 @@ mod test {
         }
         fn visit_composite<'scale, 'info>(
             self,
-            value: &mut Composite<'scale, 'info>,
-            _type_id: TypeId,
+            value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             for item in value.by_ref() {
@@ -577,8 +590,8 @@ mod test {
         }
         fn visit_tuple<'scale, 'info>(
             self,
-            value: &mut Tuple<'scale, 'info>,
-            _type_id: TypeId,
+            value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -590,14 +603,14 @@ mod test {
         fn visit_str<'scale, 'info>(
             self,
             value: &mut Str<'scale>,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
         fn visit_variant<'scale, 'info>(
             self,
-            value: &mut Variant<'scale, 'info>,
-            _type_id: TypeId,
+            value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             let fields = value.fields();
@@ -611,8 +624,8 @@ mod test {
         }
         fn visit_array<'scale, 'info>(
             self,
-            value: &mut Array<'scale, 'info>,
-            _type_id: TypeId,
+            value: &mut Array<'scale, 'info, Self::TypeResolver>,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor) {
@@ -624,7 +637,7 @@ mod test {
         fn visit_bitsequence<'scale, 'info>(
             self,
             value: &mut BitSequence<'scale>,
-            _type_id: TypeId,
+            _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
         ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
             let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
             Ok(Value::BitSequence(bools?))
@@ -941,11 +954,12 @@ mod test {
         impl Visitor for ZeroCopyStrVisitor {
             type Value<'scale, 'info> = &'scale str;
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: TypeId,
+                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -956,11 +970,12 @@ mod test {
         impl Visitor for ZeroCopyPairVisitor {
             type Value<'scale, 'info> = (&'scale str, &'scale str);
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn visit_tuple<'scale, 'info>(
                 self,
-                value: &mut Tuple<'scale, 'info>,
-                _type_id: TypeId,
+                value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let fst = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
                 let snd = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
@@ -992,11 +1007,12 @@ mod test {
         impl Visitor for ZeroCopyStrVisitor {
             type Value<'scale, 'info> = &'scale str;
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn visit_str<'scale, 'info>(
                 self,
                 value: &mut Str<'scale>,
-                _type_id: TypeId,
+                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 value.as_str()
             }
@@ -1007,11 +1023,12 @@ mod test {
         impl Visitor for ZeroCopyMapVisitor {
             type Value<'scale, 'info> = alloc::collections::BTreeMap<&'info str, &'scale str>;
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn visit_composite<'scale, 'info>(
                 self,
-                value: &mut Composite<'scale, 'info>,
-                _type_id: TypeId,
+                value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
             ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
                 let mut vals = alloc::collections::BTreeMap::<&'info str, &'scale str>::new();
                 for item in value {
@@ -1043,6 +1060,7 @@ mod test {
         impl Visitor for BailOutVisitor {
             type Value<'scale, 'info> = (&'scale [u8], u32);
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
@@ -1065,11 +1083,12 @@ mod test {
         impl<T: codec::Decode> Visitor for CodecDecodeVisitor<T> {
             type Value<'scale, 'info> = T;
             type Error = DecodeError;
+            type TypeResolver = PortableRegistry;
 
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                _type_id: TypeId,
+                _type_id: <Self::TypeResolver as TypeResolver>::TypeId,
                 _types: &'info scale_info::PortableRegistry,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -363,6 +363,12 @@ pub trait DecodeItemIterator<'scale, 'info, R: TypeResolver> {
 /// A [`Visitor`] implementation that just ignores all of the bytes.
 pub struct IgnoreVisitor<R>(std::marker::PhantomData<R>);
 
+impl<R> Default for IgnoreVisitor<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<R> IgnoreVisitor<R> {
     /// Construct a new [`IgnoreVisitor`].
     pub fn new() -> Self {
@@ -453,7 +459,7 @@ mod test {
     struct ValueVisitor<R>(std::marker::PhantomData<R>);
     impl<R> Clone for ValueVisitor<R> {
         fn clone(&self) -> Self {
-            Self(self.0)
+            *self
         }
     }
     impl<R> Copy for ValueVisitor<R> {}

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -32,7 +32,7 @@ pub type TypeIdFor<V> = <<V as Visitor>::TypeResolver as TypeResolver>::TypeId;
 /// to decide what to do with these values.
 pub trait Visitor: Sized {
     /// The type of the value to hand back from the [`decode_with_visitor()`] function.
-    type Value<'scale, 'info>;
+    type Value<'scale, 'resolver>;
     /// The error type (which we must be able to convert a combination of [`Self`] and [`DecodeError`]s
     /// into, to handle any internal errors that crop up trying to decode things).
     type Error: From<DecodeError>;
@@ -49,191 +49,191 @@ pub trait Visitor: Sized {
     /// Unlike the other `visit_*` methods, it is completely up to the implementor to decode and advance the
     /// bytes in a sensible way, and thus also possible for the implementor to screw this up. As a result,
     /// it's suggested that you don't implement this unless you know what you're doing.
-    fn unchecked_decode_as_type<'scale, 'info>(
+    fn unchecked_decode_as_type<'scale, 'resolver>(
         self,
         _input: &mut &'scale [u8],
         _type_id: &TypeIdFor<Self>,
-        _types: &'info Self::TypeResolver,
-    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+        _types: &'resolver Self::TypeResolver,
+    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>> {
         DecodeAsTypeResult::Skipped(self)
     }
 
     /// This is called when a visitor function that you've not provided an implementation is called.
     /// You are provided an enum value corresponding to the function call, and can decide what to return
     /// in this case. The default is to return an error to announce the unexpected value.
-    fn visit_unexpected<'scale, 'info>(
+    fn visit_unexpected<'scale, 'resolver>(
         self,
         unexpected: Unexpected,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Err(DecodeError::Unexpected(unexpected).into())
     }
 
     /// Called when a bool is seen in the input bytes.
-    fn visit_bool<'scale, 'info>(
+    fn visit_bool<'scale, 'resolver>(
         self,
         _value: bool,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Bool)
     }
     /// Called when a char is seen in the input bytes.
-    fn visit_char<'scale, 'info>(
+    fn visit_char<'scale, 'resolver>(
         self,
         _value: char,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Char)
     }
     /// Called when a u8 is seen in the input bytes.
-    fn visit_u8<'scale, 'info>(
+    fn visit_u8<'scale, 'resolver>(
         self,
         _value: u8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U8)
     }
     /// Called when a u16 is seen in the input bytes.
-    fn visit_u16<'scale, 'info>(
+    fn visit_u16<'scale, 'resolver>(
         self,
         _value: u16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U16)
     }
     /// Called when a u32 is seen in the input bytes.
-    fn visit_u32<'scale, 'info>(
+    fn visit_u32<'scale, 'resolver>(
         self,
         _value: u32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U32)
     }
     /// Called when a u64 is seen in the input bytes.
-    fn visit_u64<'scale, 'info>(
+    fn visit_u64<'scale, 'resolver>(
         self,
         _value: u64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U64)
     }
     /// Called when a u128 is seen in the input bytes.
-    fn visit_u128<'scale, 'info>(
+    fn visit_u128<'scale, 'resolver>(
         self,
         _value: u128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U128)
     }
     /// Called when a u256 is seen in the input bytes.
-    fn visit_u256<'scale, 'info>(
+    fn visit_u256<'scale, 'resolver>(
         self,
         _value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::U256)
     }
     /// Called when an i8 is seen in the input bytes.
-    fn visit_i8<'scale, 'info>(
+    fn visit_i8<'scale, 'resolver>(
         self,
         _value: i8,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I8)
     }
     /// Called when an i16 is seen in the input bytes.
-    fn visit_i16<'scale, 'info>(
+    fn visit_i16<'scale, 'resolver>(
         self,
         _value: i16,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I16)
     }
     /// Called when an i32 is seen in the input bytes.
-    fn visit_i32<'scale, 'info>(
+    fn visit_i32<'scale, 'resolver>(
         self,
         _value: i32,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I32)
     }
     /// Called when an i64 is seen in the input bytes.
-    fn visit_i64<'scale, 'info>(
+    fn visit_i64<'scale, 'resolver>(
         self,
         _value: i64,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I64)
     }
     /// Called when an i128 is seen in the input bytes.
-    fn visit_i128<'scale, 'info>(
+    fn visit_i128<'scale, 'resolver>(
         self,
         _value: i128,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I128)
     }
     /// Called when an i256 is seen in the input bytes.
-    fn visit_i256<'scale, 'info>(
+    fn visit_i256<'scale, 'resolver>(
         self,
         _value: &'scale [u8; 32],
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::I256)
     }
     /// Called when a sequence of values is seen in the input bytes.
-    fn visit_sequence<'scale, 'info>(
+    fn visit_sequence<'scale, 'resolver>(
         self,
-        _value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+        _value: &mut Sequence<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Sequence)
     }
     /// Called when a composite value is seen in the input bytes.
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        _value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+        _value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Composite)
     }
     /// Called when a tuple of values is seen in the input bytes.
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        _value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+        _value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Tuple)
     }
     /// Called when a string value is seen in the input bytes.
-    fn visit_str<'scale, 'info>(
+    fn visit_str<'scale, 'resolver>(
         self,
         _value: &mut Str<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Str)
     }
     /// Called when a variant is seen in the input bytes.
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        _value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+        _value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Variant)
     }
     /// Called when an array is seen in the input bytes.
-    fn visit_array<'scale, 'info>(
+    fn visit_array<'scale, 'resolver>(
         self,
-        _value: &mut Array<'scale, 'info, Self::TypeResolver>,
+        _value: &mut Array<'scale, 'resolver, Self::TypeResolver>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Array)
     }
     /// Called when a bit sequence is seen in the input bytes.
-    fn visit_bitsequence<'scale, 'info>(
+    fn visit_bitsequence<'scale, 'resolver>(
         self,
         _value: &mut BitSequence<'scale>,
         _type_id: &TypeIdFor<Self>,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         self.visit_unexpected(Unexpected::Bitsequence)
     }
 }
@@ -352,12 +352,12 @@ impl<V, R> DecodeAsTypeResult<V, R> {
 
 /// This is implemented for visitor related types which have a `decode_item` method,
 /// and allows you to generically talk about decoding unnamed items.
-pub trait DecodeItemIterator<'scale, 'info, R: TypeResolver> {
+pub trait DecodeItemIterator<'scale, 'resolver, R: TypeResolver> {
     /// Use a visitor to decode a single item.
     fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,
-    ) -> Option<Result<V::Value<'scale, 'info>, V::Error>>;
+    ) -> Option<Result<V::Value<'scale, 'resolver>, V::Error>>;
 }
 
 /// A [`Visitor`] implementation that just ignores all of the bytes.
@@ -377,15 +377,15 @@ impl<R> IgnoreVisitor<R> {
 }
 
 impl<R: TypeResolver> Visitor for IgnoreVisitor<R> {
-    type Value<'scale, 'info> = ();
+    type Value<'scale, 'resolver> = ();
     type Error = DecodeError;
     type TypeResolver = R;
 
     // Whatever the value we visit is, just ignore it.
-    fn visit_unexpected<'scale, 'info>(
+    fn visit_unexpected<'scale, 'resolver>(
         self,
         _unexpected: Unexpected,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(())
     }
 }
@@ -404,16 +404,16 @@ impl<V: Visitor> Visitor for VisitorWithCrateError<V>
 where
     V::Error: Into<crate::Error>,
 {
-    type Value<'scale, 'info> = V::Value<'scale, 'info>;
+    type Value<'scale, 'resolver> = V::Value<'scale, 'resolver>;
     type Error = crate::Error;
     type TypeResolver = V::TypeResolver;
 
-    fn unchecked_decode_as_type<'scale, 'info>(
+    fn unchecked_decode_as_type<'scale, 'resolver>(
         self,
         input: &mut &'scale [u8],
         type_id: &TypeIdFor<Self>,
-        types: &'info Self::TypeResolver,
-    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+        types: &'resolver Self::TypeResolver,
+    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>> {
         let res = decode_with_visitor(input, type_id, types, self.0).map_err(Into::into);
         DecodeAsTypeResult::Decoded(res)
     }
@@ -471,113 +471,113 @@ mod test {
     }
 
     impl<R: TypeResolver> Visitor for ValueVisitor<R> {
-        type Value<'scale, 'info> = Value;
+        type Value<'scale, 'resolver> = Value;
         type Error = DecodeError;
         type TypeResolver = R;
 
-        fn visit_bool<'scale, 'info>(
+        fn visit_bool<'scale, 'resolver>(
             self,
             value: bool,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::Bool(value))
         }
-        fn visit_char<'scale, 'info>(
+        fn visit_char<'scale, 'resolver>(
             self,
             value: char,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::Char(value))
         }
-        fn visit_u8<'scale, 'info>(
+        fn visit_u8<'scale, 'resolver>(
             self,
             value: u8,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U8(value))
         }
-        fn visit_u16<'scale, 'info>(
+        fn visit_u16<'scale, 'resolver>(
             self,
             value: u16,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U16(value))
         }
-        fn visit_u32<'scale, 'info>(
+        fn visit_u32<'scale, 'resolver>(
             self,
             value: u32,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U32(value))
         }
-        fn visit_u64<'scale, 'info>(
+        fn visit_u64<'scale, 'resolver>(
             self,
             value: u64,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U64(value))
         }
-        fn visit_u128<'scale, 'info>(
+        fn visit_u128<'scale, 'resolver>(
             self,
             value: u128,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U128(value))
         }
-        fn visit_u256<'scale, 'info>(
+        fn visit_u256<'scale, 'resolver>(
             self,
             value: &'scale [u8; 32],
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::U256(*value))
         }
-        fn visit_i8<'scale, 'info>(
+        fn visit_i8<'scale, 'resolver>(
             self,
             value: i8,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I8(value))
         }
-        fn visit_i16<'scale, 'info>(
+        fn visit_i16<'scale, 'resolver>(
             self,
             value: i16,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I16(value))
         }
-        fn visit_i32<'scale, 'info>(
+        fn visit_i32<'scale, 'resolver>(
             self,
             value: i32,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I32(value))
         }
-        fn visit_i64<'scale, 'info>(
+        fn visit_i64<'scale, 'resolver>(
             self,
             value: i64,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I64(value))
         }
-        fn visit_i128<'scale, 'info>(
+        fn visit_i128<'scale, 'resolver>(
             self,
             value: i128,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I128(value))
         }
-        fn visit_i256<'scale, 'info>(
+        fn visit_i256<'scale, 'resolver>(
             self,
             value: &'scale [u8; 32],
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::I256(*value))
         }
-        fn visit_sequence<'scale, 'info>(
+        fn visit_sequence<'scale, 'resolver>(
             self,
-            value: &mut Sequence<'scale, 'info, Self::TypeResolver>,
+            value: &mut Sequence<'scale, 'resolver, Self::TypeResolver>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
@@ -585,11 +585,11 @@ mod test {
             }
             Ok(Value::Sequence(vals))
         }
-        fn visit_composite<'scale, 'info>(
+        fn visit_composite<'scale, 'resolver>(
             self,
-            value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+            value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let mut vals = vec![];
             for item in value.by_ref() {
                 let item = item?;
@@ -599,11 +599,11 @@ mod test {
             }
             Ok(Value::Composite(vals))
         }
-        fn visit_tuple<'scale, 'info>(
+        fn visit_tuple<'scale, 'resolver>(
             self,
-            value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+            value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
@@ -611,18 +611,18 @@ mod test {
             }
             Ok(Value::Tuple(vals))
         }
-        fn visit_str<'scale, 'info>(
+        fn visit_str<'scale, 'resolver>(
             self,
             value: &mut Str<'scale>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             Ok(Value::Str(value.as_str()?.to_owned()))
         }
-        fn visit_variant<'scale, 'info>(
+        fn visit_variant<'scale, 'resolver>(
             self,
-            value: &mut Variant<'scale, 'info, Self::TypeResolver>,
+            value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let mut vals = vec![];
             let fields = value.fields();
             for item in fields.by_ref() {
@@ -633,11 +633,11 @@ mod test {
             }
             Ok(Value::Variant(value.name().to_owned(), vals))
         }
-        fn visit_array<'scale, 'info>(
+        fn visit_array<'scale, 'resolver>(
             self,
-            value: &mut Array<'scale, 'info, Self::TypeResolver>,
+            value: &mut Array<'scale, 'resolver, Self::TypeResolver>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let mut vals = vec![];
             while let Some(val) = value.decode_item(ValueVisitor::new()) {
                 let val = val?;
@@ -645,11 +645,11 @@ mod test {
             }
             Ok(Value::Array(vals))
         }
-        fn visit_bitsequence<'scale, 'info>(
+        fn visit_bitsequence<'scale, 'resolver>(
             self,
             value: &mut BitSequence<'scale>,
             _type_id: &TypeIdFor<Self>,
-        ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
             let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
             Ok(Value::BitSequence(bools?))
         }
@@ -963,15 +963,15 @@ mod test {
         // This can just zero-copy decode a string:
         struct ZeroCopyStrVisitor;
         impl Visitor for ZeroCopyStrVisitor {
-            type Value<'scale, 'info> = &'scale str;
+            type Value<'scale, 'resolver> = &'scale str;
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn visit_str<'scale, 'info>(
+            fn visit_str<'scale, 'resolver>(
                 self,
                 value: &mut Str<'scale>,
                 _type_id: &TypeIdFor<Self>,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 value.as_str()
             }
         }
@@ -979,15 +979,15 @@ mod test {
         // This can zero-copy decode the pair of strings we have as input:
         struct ZeroCopyPairVisitor;
         impl Visitor for ZeroCopyPairVisitor {
-            type Value<'scale, 'info> = (&'scale str, &'scale str);
+            type Value<'scale, 'resolver> = (&'scale str, &'scale str);
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn visit_tuple<'scale, 'info>(
+            fn visit_tuple<'scale, 'resolver>(
                 self,
-                value: &mut Tuple<'scale, 'info, Self::TypeResolver>,
+                value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
                 _type_id: &TypeIdFor<Self>,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 let fst = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
                 let snd = value.decode_item(ZeroCopyStrVisitor).unwrap()?;
                 Ok((fst, snd))
@@ -1016,15 +1016,15 @@ mod test {
         // This can just zero-copy decode a string:
         struct ZeroCopyStrVisitor;
         impl Visitor for ZeroCopyStrVisitor {
-            type Value<'scale, 'info> = &'scale str;
+            type Value<'scale, 'resolver> = &'scale str;
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn visit_str<'scale, 'info>(
+            fn visit_str<'scale, 'resolver>(
                 self,
                 value: &mut Str<'scale>,
                 _type_id: &TypeIdFor<Self>,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
                 value.as_str()
             }
         }
@@ -1032,16 +1032,17 @@ mod test {
         // This zero-copy decodes a composite into map of strings:
         struct ZeroCopyMapVisitor;
         impl Visitor for ZeroCopyMapVisitor {
-            type Value<'scale, 'info> = alloc::collections::BTreeMap<&'info str, &'scale str>;
+            type Value<'scale, 'resolver> =
+                alloc::collections::BTreeMap<&'resolver str, &'scale str>;
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn visit_composite<'scale, 'info>(
+            fn visit_composite<'scale, 'resolver>(
                 self,
-                value: &mut Composite<'scale, 'info, Self::TypeResolver>,
+                value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
                 _type_id: &TypeIdFor<Self>,
-            ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
-                let mut vals = alloc::collections::BTreeMap::<&'info str, &'scale str>::new();
+            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
+                let mut vals = alloc::collections::BTreeMap::<&'resolver str, &'scale str>::new();
                 for item in value {
                     let item = item?;
                     let Some(key) = item.name() else { continue };
@@ -1069,16 +1070,16 @@ mod test {
         // that we can successfully "bail out".
         struct BailOutVisitor;
         impl Visitor for BailOutVisitor {
-            type Value<'scale, 'info> = (&'scale [u8], u32);
+            type Value<'scale, 'resolver> = (&'scale [u8], u32);
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn unchecked_decode_as_type<'scale, 'info>(
+            fn unchecked_decode_as_type<'scale, 'resolver>(
                 self,
                 input: &mut &'scale [u8],
                 type_id: &u32,
-                _types: &'info scale_info::PortableRegistry,
-            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
+                _types: &'resolver scale_info::PortableRegistry,
+            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>>
             {
                 DecodeAsTypeResult::Decoded(Ok((*input, *type_id)))
             }
@@ -1092,16 +1093,16 @@ mod test {
         // (though obviously with the caveat that this may be incorrect).
         struct CodecDecodeVisitor<T>(core::marker::PhantomData<T>);
         impl<T: codec::Decode> Visitor for CodecDecodeVisitor<T> {
-            type Value<'scale, 'info> = T;
+            type Value<'scale, 'resolver> = T;
             type Error = DecodeError;
             type TypeResolver = PortableRegistry;
 
-            fn unchecked_decode_as_type<'scale, 'info>(
+            fn unchecked_decode_as_type<'scale, 'resolver>(
                 self,
                 input: &mut &'scale [u8],
                 _type_id: &TypeIdFor<Self>,
-                _types: &'info scale_info::PortableRegistry,
-            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
+                _types: &'resolver scale_info::PortableRegistry,
+            ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'resolver>, Self::Error>>
             {
                 DecodeAsTypeResult::Decoded(T::decode(input).map_err(|e| e.into()))
             }

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -18,6 +18,8 @@
 mod decode;
 pub mod types;
 
+use alloc::string::String;
+use core::marker::PhantomData;
 use scale_type_resolver::TypeResolver;
 use types::*;
 
@@ -361,7 +363,7 @@ pub trait DecodeItemIterator<'scale, 'resolver, R: TypeResolver> {
 }
 
 /// A [`Visitor`] implementation that just ignores all of the bytes.
-pub struct IgnoreVisitor<R>(std::marker::PhantomData<R>);
+pub struct IgnoreVisitor<R>(PhantomData<R>);
 
 impl<R> Default for IgnoreVisitor<R> {
     fn default() -> Self {
@@ -372,7 +374,7 @@ impl<R> Default for IgnoreVisitor<R> {
 impl<R> IgnoreVisitor<R> {
     /// Construct a new [`IgnoreVisitor`].
     pub fn new() -> Self {
-        IgnoreVisitor(std::marker::PhantomData)
+        IgnoreVisitor(PhantomData)
     }
 }
 
@@ -456,7 +458,7 @@ mod test {
         BitSequence(scale_bits::Bits),
     }
 
-    struct ValueVisitor<R>(std::marker::PhantomData<R>);
+    struct ValueVisitor<R>(PhantomData<R>);
     impl<R> Clone for ValueVisitor<R> {
         fn clone(&self) -> Self {
             *self
@@ -466,7 +468,7 @@ mod test {
 
     impl<R> ValueVisitor<R> {
         pub fn new() -> Self {
-            Self(std::marker::PhantomData)
+            Self(PhantomData)
         }
     }
 

--- a/scale-decode/src/visitor/types/array.rs
+++ b/scale-decode/src/visitor/types/array.rs
@@ -108,10 +108,10 @@ pub struct ArrayItem<'scale, 'info, R: TypeResolver> {
     types: &'info R,
 }
 
-impl <'scale, 'info, R: TypeResolver> Copy for ArrayItem<'scale, 'info, R> {}
-impl <'scale, 'info, R: TypeResolver> Clone for ArrayItem<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> Copy for ArrayItem<'scale, 'info, R> {}
+impl<'scale, 'info, R: TypeResolver> Clone for ArrayItem<'scale, 'info, R> {
     fn clone(&self) -> Self {
-        Self { bytes: self.bytes, type_id: self.type_id, types: self.types }
+        *self
     }
 }
 
@@ -122,7 +122,7 @@ impl<'scale, 'info, R: TypeResolver> ArrayItem<'scale, 'info, R> {
     }
     /// The type ID associated with this item.
     pub fn type_id(&self) -> &R::TypeId {
-        &self.type_id
+        self.type_id
     }
     /// Decode this item using a visitor.
     pub fn decode_with_visitor<V: Visitor<TypeResolver = R>>(

--- a/scale-decode/src/visitor/types/array.rs
+++ b/scale-decode/src/visitor/types/array.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use scale_type_resolver::TypeResolver;
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
     DecodeAsType,
 };
+use scale_type_resolver::TypeResolver;
 
 /// This enables a visitor to decode items from an array type.
 pub struct Array<'scale, 'info, R: TypeResolver> {
@@ -131,7 +131,9 @@ impl<'scale, 'info, R: TypeResolver> ArrayItem<'scale, 'info, R> {
     }
 }
 
-impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R> for Array<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R>
+    for Array<'scale, 'info, R>
+{
     fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,

--- a/scale-decode/src/visitor/types/array.rs
+++ b/scale-decode/src/visitor/types/array.rs
@@ -74,7 +74,7 @@ impl<'scale, 'info, R: TypeResolver> Array<'scale, 'info, R> {
         let b = &mut self.item_bytes;
         // Don't return here; decrement bytes and remaining properly first and then return, so that
         // calling decode_item again works as expected.
-        let res = crate::visitor::decode_with_visitor(b, self.type_id, self.types, visitor);
+        let res = crate::visitor::decode_with_visitor(b, self.type_id.clone(), self.types, visitor);
         self.item_bytes = *b;
         self.remaining -= 1;
         Some(res)
@@ -97,7 +97,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Array<'scale, 'info, R> {
         let num_bytes_after = self.item_bytes.len();
         let res_bytes = &item_bytes[..num_bytes_before - num_bytes_after];
 
-        Some(Ok(ArrayItem { bytes: res_bytes, type_id: self.type_id, types: self.types }))
+        Some(Ok(ArrayItem { bytes: res_bytes, type_id: self.type_id.clone(), types: self.types }))
     }
 }
 
@@ -123,11 +123,11 @@ impl<'scale, 'info, R: TypeResolver> ArrayItem<'scale, 'info, R> {
         &self,
         visitor: V,
     ) -> Result<V::Value<'scale, 'info>, V::Error> {
-        crate::visitor::decode_with_visitor(&mut &*self.bytes, self.type_id, self.types, visitor)
+        crate::visitor::decode_with_visitor(&mut &*self.bytes, self.type_id.clone(), self.types, visitor)
     }
     /// Decode this item into a specific type via [`DecodeAsType`].
     pub fn decode_as_type<T: DecodeAsType>(&self) -> Result<T, crate::Error> {
-        T::decode_as_type(&mut &*self.bytes, self.type_id, self.types)
+        T::decode_as_type(&mut &*self.bytes, self.type_id.clone(), self.types)
     }
 }
 

--- a/scale-decode/src/visitor/types/array.rs
+++ b/scale-decode/src/visitor/types/array.rs
@@ -102,11 +102,17 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Array<'scale, 'info, R> {
 }
 
 /// A single item in the array.
-#[derive(Clone)]
 pub struct ArrayItem<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
     type_id: &'info R::TypeId,
     types: &'info R,
+}
+
+impl <'scale, 'info, R: TypeResolver> Copy for ArrayItem<'scale, 'info, R> {}
+impl <'scale, 'info, R: TypeResolver> Clone for ArrayItem<'scale, 'info, R> {
+    fn clone(&self) -> Self {
+        Self { bytes: self.bytes, type_id: self.type_id, types: self.types }
+    }
 }
 
 impl<'scale, 'info, R: TypeResolver> ArrayItem<'scale, 'info, R> {

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -124,7 +124,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Composite<'scale, 'info, R> {
     type Item = Result<CompositeField<'scale, 'info, R>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
         // Record details we need before we decode and skip over the thing:
-        let field = self.fields.get(self.next_field_idx)?.clone();
+        let field = *self.fields.get(self.next_field_idx)?;
         let num_bytes_before = self.item_bytes.len();
         let item_bytes = self.item_bytes;
 
@@ -157,12 +157,7 @@ pub struct CompositeField<'scale, 'info, R: TypeResolver> {
 impl<'scale, 'info, R: TypeResolver> Copy for CompositeField<'scale, 'info, R> {}
 impl<'scale, 'info, R: TypeResolver> Clone for CompositeField<'scale, 'info, R> {
     fn clone(&self) -> Self {
-        Self {
-            bytes: self.bytes,
-            field: self.field,
-            types: self.types,
-            is_compact: self.is_compact,
-        }
+        *self
     }
 }
 
@@ -177,7 +172,7 @@ impl<'scale, 'info, R: TypeResolver> CompositeField<'scale, 'info, R> {
     }
     /// The type ID associated with this field.
     pub fn type_id(&self) -> &R::TypeId {
-        &self.field.id
+        self.field.id
     }
     /// If the field is compact encoded
     pub fn is_compact(&self) -> bool {

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -100,7 +100,7 @@ impl<'scale, 'info, R: TypeResolver> Composite<'scale, 'info, R> {
         // Decode the bytes:
         let res = crate::visitor::decode_with_visitor_maybe_compact(
             b,
-            field.id.clone(),
+            field.id,
             self.types,
             visitor,
             self.is_compact,

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -23,7 +23,6 @@ use scale_type_resolver::{Field, TypeResolver};
 pub struct Composite<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
     item_bytes: &'scale [u8],
-    // path: &'info Path<PortableForm>,
     fields: smallvec::SmallVec<[Field<'info, R::TypeId>; 16]>,
     next_field_idx: usize,
     types: &'info R,
@@ -35,7 +34,6 @@ impl<'scale, 'info, R: TypeResolver> Composite<'scale, 'info, R> {
     #[doc(hidden)]
     pub fn new(
         bytes: &'scale [u8],
-        // path: &'info Path<PortableForm>,
         fields: &mut dyn FieldIter<'info, R::TypeId>,
         types: &'info R,
         is_compact: bool,

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -146,12 +146,19 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Composite<'scale, 'info, R> {
 }
 
 /// A single field in the composite type.
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct CompositeField<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
     field: Field<'info, R::TypeId>,
     types: &'info R,
     is_compact: bool,
+}
+
+impl <'scale, 'info, R: TypeResolver> Copy for CompositeField<'scale, 'info, R> {}
+impl <'scale, 'info, R: TypeResolver> Clone for CompositeField<'scale, 'info, R> {
+    fn clone(&self) -> Self {
+        Self { bytes: self.bytes, field: self.field, types: self.types, is_compact: self.is_compact }
+    }
 }
 
 impl<'scale, 'info, R: TypeResolver> CompositeField<'scale, 'info, R> {

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
-    DecodeAsType, FieldIter
+    DecodeAsType, FieldIter,
 };
 use scale_type_resolver::{Field, TypeResolver};
 
@@ -154,10 +154,15 @@ pub struct CompositeField<'scale, 'info, R: TypeResolver> {
     is_compact: bool,
 }
 
-impl <'scale, 'info, R: TypeResolver> Copy for CompositeField<'scale, 'info, R> {}
-impl <'scale, 'info, R: TypeResolver> Clone for CompositeField<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> Copy for CompositeField<'scale, 'info, R> {}
+impl<'scale, 'info, R: TypeResolver> Clone for CompositeField<'scale, 'info, R> {
     fn clone(&self) -> Self {
-        Self { bytes: self.bytes, field: self.field, types: self.types, is_compact: self.is_compact }
+        Self {
+            bytes: self.bytes,
+            field: self.field,
+            types: self.types,
+            is_compact: self.is_compact,
+        }
     }
 }
 
@@ -202,7 +207,9 @@ impl<'scale, 'info, R: TypeResolver> CompositeField<'scale, 'info, R> {
     }
 }
 
-impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R> for Composite<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R>
+    for Composite<'scale, 'info, R>
+{
     fn decode_item<'a, V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -79,10 +79,16 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Sequence<'scale, 'info, R> {
 }
 
 /// A single item in the Sequence.
-#[derive(Clone)]
 pub struct SequenceItem<'scale, 'info, R: TypeResolver> {
     // Same implementation under the hood as ArrayItem:
     item: ArrayItem<'scale, 'info, R>,
+}
+
+impl <'scale, 'info, R: TypeResolver> Copy for SequenceItem<'scale, 'info, R> {}
+impl <'scale, 'info, R: TypeResolver> Clone for SequenceItem<'scale, 'info, R> {
+    fn clone(&self) -> Self {
+        Self { item: self.item }
+    }
 }
 
 impl<'scale, 'info, R: TypeResolver> SequenceItem<'scale, 'info, R> {

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -107,7 +107,9 @@ impl<'scale, 'info, R: TypeResolver> SequenceItem<'scale, 'info, R> {
     }
 }
 
-impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R> for Sequence<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R>
+    for Sequence<'scale, 'info, R>
+{
     fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -84,10 +84,10 @@ pub struct SequenceItem<'scale, 'info, R: TypeResolver> {
     item: ArrayItem<'scale, 'info, R>,
 }
 
-impl <'scale, 'info, R: TypeResolver> Copy for SequenceItem<'scale, 'info, R> {}
-impl <'scale, 'info, R: TypeResolver> Clone for SequenceItem<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> Copy for SequenceItem<'scale, 'info, R> {}
+impl<'scale, 'info, R: TypeResolver> Clone for SequenceItem<'scale, 'info, R> {
     fn clone(&self) -> Self {
-        Self { item: self.item }
+        *self
     }
 }
 

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -62,7 +62,7 @@ impl<'scale, 'info, R: TypeResolver> Sequence<'scale, 'info, R> {
         self.values.remaining()
     }
     /// Decode an item from the sequence by providing a visitor to handle it.
-    pub fn decode_item<V: Visitor>(
+    pub fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {
@@ -91,11 +91,11 @@ impl<'scale, 'info, R: TypeResolver> SequenceItem<'scale, 'info, R> {
         self.item.bytes()
     }
     /// The type ID associated with this item.
-    pub fn type_id(&self) -> u32 {
+    pub fn type_id(&self) -> &R::TypeId {
         self.item.type_id()
     }
     /// Decode this item using a visitor.
-    pub fn decode_with_visitor<V: Visitor>(
+    pub fn decode_with_visitor<V: Visitor<TypeResolver = R>>(
         &self,
         visitor: V,
     ) -> Result<V::Value<'scale, 'info>, V::Error> {

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -33,7 +33,7 @@ pub struct Sequence<'scale, 'info, R: TypeResolver> {
 impl<'scale, 'info, R: TypeResolver> Sequence<'scale, 'info, R> {
     pub(crate) fn new(
         bytes: &'scale [u8],
-        type_id: R::TypeId,
+        type_id: &'info R::TypeId,
         types: &'info R,
     ) -> Result<Sequence<'scale, 'info, R>, DecodeError> {
         // Sequences are prefixed with their length in bytes. Make a note of this,
@@ -108,7 +108,7 @@ impl<'scale, 'info, R: TypeResolver> SequenceItem<'scale, 'info, R> {
 }
 
 impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R> for Sequence<'scale, 'info, R> {
-    fn decode_item<'a, V: Visitor<TypeResolver = R>>(
+    fn decode_item<V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,
     ) -> Option<Result<V::Value<'scale, 'info>, V::Error>> {

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -17,7 +17,7 @@ use crate::{
     visitor::{DecodeError, IgnoreVisitor, Visitor},
     DecodeAsType, FieldIter,
 };
-use scale_type_resolver::{ Field, TypeResolver };
+use scale_type_resolver::{Field, TypeResolver};
 
 /// This represents a tuple of values.
 pub struct Tuple<'scale, 'info, R: TypeResolver> {
@@ -156,7 +156,9 @@ impl<'scale, 'info, R: TypeResolver> TupleField<'scale, 'info, R> {
     }
 }
 
-impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R> for Tuple<'scale, 'info, R> {
+impl<'scale, 'info, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'info, R>
+    for Tuple<'scale, 'info, R>
+{
     fn decode_item<'a, V: Visitor<TypeResolver = R>>(
         &mut self,
         visitor: V,

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -94,7 +94,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Tuple<'scale, 'info, R> {
     type Item = Result<TupleField<'scale, 'info, R>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
         // Record details we need before we decode and skip over the thing:
-        let field = self.fields.get(self.next_field_idx)?.clone();
+        let field = *self.fields.get(self.next_field_idx)?;
         let num_bytes_before = self.item_bytes.len();
         let item_bytes = self.item_bytes;
 
@@ -132,7 +132,7 @@ impl<'scale, 'info, R: TypeResolver> TupleField<'scale, 'info, R> {
     }
     /// The type ID associated with this field.
     pub fn type_id(&self) -> &R::TypeId {
-        &self.type_id
+        self.type_id
     }
     /// If the field is compact encoded
     pub fn is_compact(&self) -> bool {

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -94,7 +94,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Tuple<'scale, 'info, R> {
     type Item = Result<TupleField<'scale, 'info, R>, DecodeError>;
     fn next(&mut self) -> Option<Self::Item> {
         // Record details we need before we decode and skip over the thing:
-        let field = *self.fields.get(self.next_field_idx)?;
+        let field = self.fields.get(self.next_field_idx)?.clone();
         let num_bytes_before = self.item_bytes.len();
         let item_bytes = self.item_bytes;
 
@@ -120,7 +120,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Tuple<'scale, 'info, R> {
 #[derive(Copy, Clone)]
 pub struct TupleField<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
-    type_id: R::TypeId,
+    type_id: &'info R::TypeId,
     types: &'info R,
     is_compact: bool,
 }

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -117,7 +117,7 @@ impl<'scale, 'info, R: TypeResolver> Iterator for Tuple<'scale, 'info, R> {
 }
 
 /// A single field in the tuple type.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TupleField<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
     type_id: &'info R::TypeId,

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::visitor::{Composite, DecodeError};
-use scale_type_resolver::{ FieldIter, VariantIter, TypeResolver };
+use scale_type_resolver::{FieldIter, TypeResolver, VariantIter};
 
 /// A representation of the a variant type.
 pub struct Variant<'scale, 'info, R: TypeResolver> {
@@ -25,7 +25,10 @@ pub struct Variant<'scale, 'info, R: TypeResolver> {
 }
 
 impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
-    pub(crate) fn new<Fields: FieldIter<'info, R::TypeId> + 'info, Variants: VariantIter<'info, Fields>>(
+    pub(crate) fn new<
+        Fields: FieldIter<'info, R::TypeId> + 'info,
+        Variants: VariantIter<'info, Fields>,
+    >(
         bytes: &'scale [u8],
         mut variants: Variants,
         types: &'info R,

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -45,7 +45,7 @@ impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
         // let mut fields_iter = variant.fields.map(|f| Field::new(f.id, f.name.as_deref()));
         let fields = Composite::new(item_bytes, &mut variant.fields, types, false);
 
-        Ok(Variant { bytes, variant_index: index, variant_name: &variant.name, fields })
+        Ok(Variant { bytes, variant_index: index, variant_name: variant.name, fields })
     }
 }
 
@@ -66,7 +66,7 @@ impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
     }
     /// The name of the variant.
     pub fn name(&self) -> &'info str {
-        &self.variant_name
+        self.variant_name
     }
     /// The index of the variant.
     pub fn index(&self) -> u8 {

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -25,7 +25,7 @@ pub struct Variant<'scale, 'info, R: TypeResolver> {
 }
 
 impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
-    pub(crate) fn new<Fields: FieldIter<'info, R::TypeId>, Variants: VariantIter<'info, Fields>>(
+    pub(crate) fn new<Fields: FieldIter<'info, R::TypeId> + 'info, Variants: VariantIter<'info, Fields>>(
         bytes: &'scale [u8],
         mut variants: Variants,
         types: &'info R,

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -17,22 +17,22 @@ use crate::visitor::{Composite, DecodeError};
 use scale_type_resolver::{FieldIter, TypeResolver, VariantIter};
 
 /// A representation of the a variant type.
-pub struct Variant<'scale, 'info, R: TypeResolver> {
+pub struct Variant<'scale, 'resolver, R: TypeResolver> {
     bytes: &'scale [u8],
-    variant_name: &'info str,
+    variant_name: &'resolver str,
     variant_index: u8,
-    fields: Composite<'scale, 'info, R>,
+    fields: Composite<'scale, 'resolver, R>,
 }
 
-impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
+impl<'scale, 'resolver, R: TypeResolver> Variant<'scale, 'resolver, R> {
     pub(crate) fn new<
-        Fields: FieldIter<'info, R::TypeId> + 'info,
-        Variants: VariantIter<'info, Fields>,
+        Fields: FieldIter<'resolver, R::TypeId> + 'resolver,
+        Variants: VariantIter<'resolver, Fields>,
     >(
         bytes: &'scale [u8],
         mut variants: Variants,
-        types: &'info R,
-    ) -> Result<Variant<'scale, 'info, R>, DecodeError> {
+        types: &'resolver R,
+    ) -> Result<Variant<'scale, 'resolver, R>, DecodeError> {
         let index = *bytes.first().ok_or(DecodeError::NotEnoughInput)?;
         let item_bytes = &bytes[1..];
 
@@ -49,7 +49,7 @@ impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
     }
 }
 
-impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
+impl<'scale, 'resolver, R: TypeResolver> Variant<'scale, 'resolver, R> {
     /// Skip over all bytes associated with this variant. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this variant.
     pub fn skip_decoding(&mut self) -> Result<(), DecodeError> {
@@ -65,7 +65,7 @@ impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
         self.fields.bytes_from_undecoded()
     }
     /// The name of the variant.
-    pub fn name(&self) -> &'info str {
+    pub fn name(&self) -> &'resolver str {
         self.variant_name
     }
     /// The index of the variant.
@@ -73,7 +73,7 @@ impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
         self.variant_index
     }
     /// Access the variant fields.
-    pub fn fields(&mut self) -> &mut Composite<'scale, 'info, R> {
+    pub fn fields(&mut self) -> &mut Composite<'scale, 'resolver, R> {
         &mut self.fields
     }
 }

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -14,43 +14,39 @@
 // limitations under the License.
 
 use crate::visitor::{Composite, DecodeError};
-use crate::Field;
-use scale_info::form::PortableForm;
-use scale_info::{Path, PortableRegistry, TypeDefVariant};
+use scale_type_resolver::{ FieldIter, VariantIter, TypeResolver };
 
 /// A representation of the a variant type.
-pub struct Variant<'scale, 'info> {
+pub struct Variant<'scale, 'info, R: TypeResolver> {
     bytes: &'scale [u8],
-    variant: &'info scale_info::Variant<PortableForm>,
-    fields: Composite<'scale, 'info>,
+    variant_name: &'info str,
+    variant_index: u8,
+    fields: Composite<'scale, 'info, R>,
 }
 
-impl<'scale, 'info> Variant<'scale, 'info> {
-    pub(crate) fn new(
+impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
+    pub(crate) fn new<Fields: FieldIter<'info, R::TypeId>, Variants: VariantIter<'info, Fields>>(
         bytes: &'scale [u8],
-        path: &'info Path<PortableForm>,
-        ty: &'info TypeDefVariant<PortableForm>,
-        types: &'info PortableRegistry,
-    ) -> Result<Variant<'scale, 'info>, DecodeError> {
+        mut variants: Variants,
+        types: &'info R,
+    ) -> Result<Variant<'scale, 'info, R>, DecodeError> {
         let index = *bytes.first().ok_or(DecodeError::NotEnoughInput)?;
         let item_bytes = &bytes[1..];
 
         // Does a variant exist with the index we're looking for?
-        let variant = ty
-            .variants
-            .iter()
+        let mut variant = variants
             .find(|v| v.index == index)
-            .ok_or_else(|| DecodeError::VariantNotFound(index, ty.clone()))?;
+            .ok_or_else(|| DecodeError::VariantNotFound(index))?;
 
         // Allow decoding of the fields:
-        let mut fields_iter = variant.fields.iter().map(|f| Field::new(f.ty.id, f.name.as_deref()));
-        let fields = Composite::new(item_bytes, path, &mut fields_iter, types, false);
+        // let mut fields_iter = variant.fields.map(|f| Field::new(f.id, f.name.as_deref()));
+        let fields = Composite::new(item_bytes, &mut variant.fields, types, false);
 
-        Ok(Variant { bytes, variant, fields })
+        Ok(Variant { bytes, variant_index: index, variant_name: &variant.name, fields })
     }
 }
 
-impl<'scale, 'info> Variant<'scale, 'info> {
+impl<'scale, 'info, R: TypeResolver> Variant<'scale, 'info, R> {
     /// Skip over all bytes associated with this variant. After calling this,
     /// [`Self::bytes_from_undecoded()`] will represent the bytes after this variant.
     pub fn skip_decoding(&mut self) -> Result<(), DecodeError> {
@@ -65,20 +61,16 @@ impl<'scale, 'info> Variant<'scale, 'info> {
     pub fn bytes_from_undecoded(&self) -> &'scale [u8] {
         self.fields.bytes_from_undecoded()
     }
-    /// Path to this type.
-    pub fn path(&self) -> &'info Path<PortableForm> {
-        self.fields.path()
-    }
     /// The name of the variant.
     pub fn name(&self) -> &'info str {
-        &self.variant.name
+        &self.variant_name
     }
     /// The index of the variant.
     pub fn index(&self) -> u8 {
-        self.variant.index
+        self.variant_index
     }
     /// Access the variant fields.
-    pub fn fields(&mut self) -> &mut Composite<'scale, 'info> {
+    pub fn fields(&mut self) -> &mut Composite<'scale, 'info, R> {
         &mut self.fields
     }
 }

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -42,7 +42,6 @@ impl<'scale, 'resolver, R: TypeResolver> Variant<'scale, 'resolver, R> {
             .ok_or_else(|| DecodeError::VariantNotFound(index))?;
 
         // Allow decoding of the fields:
-        // let mut fields_iter = variant.fields.map(|f| Field::new(f.id, f.name.as_deref()));
         let fields = Composite::new(item_bytes, &mut variant.fields, types, false);
 
         Ok(Variant { bytes, variant_index: index, variant_name: variant.name, fields })


### PR DESCRIPTION
This lays the foundation for being able to use this crate in conjunction with a legacy type resolver in order to decode pre-V14 metadata. Basically, we make everything generic over how to resolve type information, and alter the decoding logic to handle this.

Once https://github.com/paritytech/scale-bits/pull/4 merges and a release done, dependencies here can be updated to make things work. 