### PR TITLE
Remove now-unneeded scale-info dep

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,6 +146,16 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  diff-readme-files:
+    name: Check that READMEs are identical
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Diff READMEs
+        run: diff -q README.md scale-decode/README.md
+
   docs:
     name: Check documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check:
     name: Cargo check
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +31,7 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Check all features
         uses: actions-rs/cargo@v1.0.3
@@ -44,6 +44,31 @@ jobs:
         with:
           command: check
           args: --all-targets --no-default-features --workspace
+
+  machete:
+    name: Check unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      - name: Install cargo-machete
+        run: cargo install cargo-machete
+
+      - name: Check unused dependencies
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: machete
 
   wasm:
     name: Check WASM compatibility
@@ -61,7 +86,7 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Check all features
         uses: actions-rs/cargo@v1.0.3
@@ -87,7 +112,7 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Check no_std build
         uses: actions-rs/cargo@v1.0.3
@@ -113,7 +138,7 @@ jobs:
             components: rustfmt
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Cargo fmt
         uses: actions-rs/cargo@v1.0.3
@@ -136,7 +161,7 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Check internal documentation links
         run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc -vv --workspace --no-deps --document-private-items
@@ -156,7 +181,7 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Cargo test
         uses: actions-rs/cargo@v1.0.3
@@ -192,7 +217,7 @@ jobs:
             override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Run clippy
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,5 +17,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.10.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.10.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.11.0", path = "scale-decode" }
+scale-decode-derive = { version = "0.11.0", path = "scale-decode-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,5 +17,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.11.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.11.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.10.0", path = "scale-decode" }
+scale-decode-derive = { version = "0.10.0", path = "scale-decode-derive" }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
     }
-}
+}s
 ```
 
 This can then be passed to a decode function like so:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
     }
-}s
+}
 ```
 
 This can then be passed to a decode function like so:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # scale-decode
 
-This crate makes it easy to decode SCALE encoded bytes into a custom data structure with the help of `scale_info` types.
-By using this type information to guide decoding (instead of just trying to decode bytes based on the shape of the target type),
-it's possible to be much more flexible in how data is decoded and mapped to some target type.
+This crate makes it easy to decode SCALE encoded bytes into a custom data structure with the help of a `TypeResolver` (one of which
+is a `scale_info::PortableRegistry`). By using this type information to guide decoding (instead of just trying to decode bytes based
+on the shape of the target type), it's possible to be much more flexible in how data is decoded and mapped to some target type.
 
 The main trait used to decode types is a `Visitor` trait (example below). By implementing this trait, you can describe how to
 take SCALE decoded values and map them to some custom type of your choosing (whether it is a dynamically shaped type or some
@@ -21,10 +21,12 @@ generated.
 Here's an example of implementing `Visitor` to decode bytes into a custom `Value` type:
 
 ```rust
+use std::marker::PhantomData;
+use scale_decode::TypeResolver;
 use scale_decode::visitor::{
     self,
     types::{Array, BitSequence, Composite, Sequence, Str, Tuple, Variant},
-    TypeId,
+    TypeIdFor,
 };
 
 // A custom type we'd like to decode into:
@@ -54,187 +56,197 @@ enum Value {
 }
 
 // Implement the `Visitor` trait to define how to go from SCALE
-// values into this type:
-struct ValueVisitor;
-impl visitor::Visitor for ValueVisitor {
-    type Value<'scale, 'info> = Value;
-    type Error = visitor::DecodeError;
+// values into this type. Here, we are choosing to be generic over
+// how types are resolved, which is a good default choice when creating
+// a visitor unless you rely on a specific type resolver/ID type.
+struct ValueVisitor<R>(PhantomData<R>);
 
-    fn visit_bool<'scale, 'info>(
+impl<R> ValueVisitor<R> {
+    fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<R: TypeResolver> visitor::Visitor for ValueVisitor<R> {
+    type Value<'scale, 'resolver> = Value;
+    type Error = visitor::DecodeError;
+    type TypeResolver = R;
+
+    fn visit_bool<'scale, 'resolver>(
         self,
         value: bool,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Bool(value))
     }
-    fn visit_char<'scale, 'info>(
+    fn visit_char<'scale, 'resolver>(
         self,
         value: char,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Char(value))
     }
-    fn visit_u8<'scale, 'info>(
+    fn visit_u8<'scale, 'resolver>(
         self,
         value: u8,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U8(value))
     }
-    fn visit_u16<'scale, 'info>(
+    fn visit_u16<'scale, 'resolver>(
         self,
         value: u16,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U16(value))
     }
-    fn visit_u32<'scale, 'info>(
+    fn visit_u32<'scale, 'resolver>(
         self,
         value: u32,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U32(value))
     }
-    fn visit_u64<'scale, 'info>(
+    fn visit_u64<'scale, 'resolver>(
         self,
         value: u64,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U64(value))
     }
-    fn visit_u128<'scale, 'info>(
+    fn visit_u128<'scale, 'resolver>(
         self,
         value: u128,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U128(value))
     }
-    fn visit_u256<'info>(
+    fn visit_u256<'scale, 'resolver>(
         self,
-        value: &'_ [u8; 32],
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        value: &'scale [u8; 32],
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::U256(*value))
     }
-    fn visit_i8<'scale, 'info>(
+    fn visit_i8<'scale, 'resolver>(
         self,
         value: i8,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I8(value))
     }
-    fn visit_i16<'scale, 'info>(
+    fn visit_i16<'scale, 'resolver>(
         self,
         value: i16,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I16(value))
     }
-    fn visit_i32<'scale, 'info>(
+    fn visit_i32<'scale, 'resolver>(
         self,
         value: i32,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I32(value))
     }
-    fn visit_i64<'scale, 'info>(
+    fn visit_i64<'scale, 'resolver>(
         self,
         value: i64,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I64(value))
     }
-    fn visit_i128<'scale, 'info>(
+    fn visit_i128<'scale, 'resolver>(
         self,
         value: i128,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I128(value))
     }
-    fn visit_i256<'info>(
+    fn visit_i256<'scale, 'resolver>(
         self,
-        value: &'_ [u8; 32],
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'_, 'info>, Self::Error> {
+        value: &'scale [u8; 32],
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::I256(*value))
     }
-    fn visit_sequence<'scale, 'info>(
+    fn visit_sequence<'scale, 'resolver>(
         self,
-        value: &mut Sequence<'scale, 'info>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        value: &mut Sequence<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
         Ok(Value::Sequence(vals))
     }
-    fn visit_composite<'scale, 'info>(
+    fn visit_composite<'scale, 'resolver>(
         self,
-        value: &mut Composite<'scale, 'info>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         for item in value.by_ref() {
             let item = item?;
-            let val = item.decode_with_visitor(ValueVisitor)?;
+            let val = item.decode_with_visitor(ValueVisitor::new())?;
             let name = item.name().unwrap_or("").to_owned();
             vals.push((name, val));
         }
         Ok(Value::Composite(vals))
     }
-    fn visit_tuple<'scale, 'info>(
+    fn visit_tuple<'scale, 'resolver>(
         self,
-        value: &mut Tuple<'scale, 'info>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        value: &mut Tuple<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
         Ok(Value::Tuple(vals))
     }
-    fn visit_str<'scale, 'info>(
+    fn visit_str<'scale, 'resolver>(
         self,
         value: &mut Str<'scale>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         Ok(Value::Str(value.as_str()?.to_owned()))
     }
-    fn visit_variant<'scale, 'info>(
+    fn visit_variant<'scale, 'resolver>(
         self,
-        value: &mut Variant<'scale, 'info>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
         let fields = value.fields();
         for item in fields.by_ref() {
             let item = item?;
-            let val = item.decode_with_visitor(ValueVisitor)?;
+            let val = item.decode_with_visitor(ValueVisitor::new())?;
             let name = item.name().unwrap_or("").to_owned();
             vals.push((name, val));
         }
         Ok(Value::Variant(value.name().to_owned(), vals))
     }
-    fn visit_array<'scale, 'info>(
+    fn visit_array<'scale, 'resolver>(
         self,
-        value: &mut Array<'scale, 'info>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        value: &mut Array<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let mut vals = vec![];
-        while let Some(val) = value.decode_item(ValueVisitor) {
+        while let Some(val) = value.decode_item(ValueVisitor::new()) {
             let val = val?;
             vals.push(val);
         }
         Ok(Value::Array(vals))
     }
-    fn visit_bitsequence<'scale, 'info>(
+    fn visit_bitsequence<'scale, 'resolver>(
         self,
         value: &mut BitSequence<'scale>,
-        _type_id: TypeId,
-    ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
+        _type_id: &TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
         let bools: Result<scale_bits::Bits, _> = value.decode()?.collect();
         Ok(Value::BitSequence(bools?))
     }
@@ -244,20 +256,20 @@ impl visitor::Visitor for ValueVisitor {
 This can then be passed to a decode function like so:
 
 ```rust
-let value: Value = scale_decode::visitor::decode_with_visitor(scale_bytes, type_id, types, ValueVisitor)?;
+let value: Value = scale_decode::visitor::decode_with_visitor(scale_bytes, &type_id, &types, ValueVisitor::new())?;
 ```
 
 Where `scale_bytes` are the bytes you'd like to decode, `type_id` is the type stored in the `types` registry
-that you'd like to try and decode the bytes into, and `types` is a `scale_info::PortableRegistry` containing
-information about the various types in use.
+that you'd like to try and decode the bytes into, and `types` is a `scale_type_resolver::TypeResolver` containing
+information about the various types in use (a concrete implementation of this is `scale_info::PortableRegistry`).
 
 If we were to then write an `IntoVisitor` implementation like so:
 
 ```rust
 impl scale_decode::IntoVisitor for Value {
-    type Visitor = ValueVisitor;
-    fn into_visitor() -> Self::Visitor {
-        ValueVisitor
+    type AnyVisitor<R: TypeResolver> = ValueVisitor<R>;
+    fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R> {
+        ValueVisitor::new()
     }
 }
 ```

--- a/scale-decode-derive/Cargo.toml
+++ b/scale-decode-derive/Cargo.toml
@@ -20,5 +20,4 @@ proc-macro = true
 syn = { version = "1", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate = "1"
 darling = "0.14.2"

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -26,7 +26,6 @@ primitive-types = ["dep:primitive-types"]
 derive = ["dep:scale-decode-derive"]
 
 [dependencies]
-scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"] }
 scale-decode-derive = { workspace = true, optional = true }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -17,7 +17,7 @@ include.workspace = true
 default = ["std", "derive", "primitive-types"]
 
 # Activates std feature.
-std = ["scale-info/std"]
+std = []
 
 # Impls for primitive-types.
 primitive-types = ["dep:primitive-types"]
@@ -27,7 +27,7 @@ derive = ["dep:scale-decode-derive"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"] }
+scale-bits = { version = "0.5.0", default-features = false }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
@@ -40,4 +40,5 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 bitvec = { version = "1.0.1", default-features = false }
 trybuild = "1.0.72"
 # Enable the scale-info feature for testing.
+scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"] }
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }

--- a/scale-decode/README.md
+++ b/scale-decode/README.md
@@ -1,8 +1,8 @@
 # scale-decode
 
-This crate makes it easy to decode SCALE encoded bytes into a custom data structure with the help of `scale_info` types.
-By using this type information to guide decoding (instead of just trying to decode bytes based on the shape of the target type),
-it's possible to be much more flexible in how data is decoded and mapped to some target type.
+This crate makes it easy to decode SCALE encoded bytes into a custom data structure with the help of a `TypeResolver` (one of which
+is a `scale_info::PortableRegistry`). By using this type information to guide decoding (instead of just trying to decode bytes based
+on the shape of the target type), it's possible to be much more flexible in how data is decoded and mapped to some target type.
 
 The main trait used to decode types is a `Visitor` trait (example below). By implementing this trait, you can describe how to
 take SCALE decoded values and map them to some custom type of your choosing (whether it is a dynamically shaped type or some
@@ -260,8 +260,8 @@ let value: Value = scale_decode::visitor::decode_with_visitor(scale_bytes, &type
 ```
 
 Where `scale_bytes` are the bytes you'd like to decode, `type_id` is the type stored in the `types` registry
-that you'd like to try and decode the bytes into, and `types` is a `scale_info::PortableRegistry` containing
-information about the various types in use.
+that you'd like to try and decode the bytes into, and `types` is a `scale_type_resolver::TypeResolver` containing
+information about the various types in use (a concrete implementation of this is `scale_info::PortableRegistry`).
 
 If we were to then write an `IntoVisitor` implementation like so:
 

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -766,8 +766,7 @@ mod test {
 
         let new_foo = match &types.resolve(ty).unwrap().type_def {
             scale_info::TypeDef::Composite(c) => {
-                let mut field_iter =
-                    c.fields.iter().map(|f| Field::new(&f.ty.id, f.name));
+                let mut field_iter = c.fields.iter().map(|f| Field::new(&f.ty.id, f.name));
                 Foo::decode_as_fields(foo_encoded_cursor, &mut field_iter, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {

--- a/scale-decode/src/impls/mod.rs
+++ b/scale-decode/src/impls/mod.rs
@@ -767,7 +767,7 @@ mod test {
         let new_foo = match &types.resolve(ty).unwrap().type_def {
             scale_info::TypeDef::Composite(c) => {
                 let mut field_iter =
-                    c.fields.iter().map(|f| Field::new(&f.ty.id, f.name.as_deref()));
+                    c.fields.iter().map(|f| Field::new(&f.ty.id, f.name));
                 Foo::decode_as_fields(foo_encoded_cursor, &mut field_iter, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -16,8 +16,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 /*!
-`parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those types.
-This crate builds on this, and allows bytes to be decoded into types based on [`scale_info`] type information, rather than the shape
+`parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those
+types. This crate builds on this, and allows bytes to be decoded into types based on type information, rather than the shape
 of the target type. At a high level, this crate just aims to do the reverse of the `scale-encode` crate.
 
 This crate exposes four traits:
@@ -26,7 +26,7 @@ This crate exposes four traits:
   to decode SCALE encoded bytes based on some type information into some arbitrary type.
 - An [`IntoVisitor`] trait which can be used to obtain the [`visitor::Visitor`] implementation for some type.
 - A [`DecodeAsType`] trait which is implemented for types which implement [`IntoVisitor`], and provides a high level interface for
-  decoding SCALE encoded bytes into some type with the help of a type ID and [`scale_info::PortableRegistry`].
+  decoding SCALE encoded bytes into some type with the help of a type ID and a [`scale_type_resolver::TypeResolver`].
 - A [`DecodeAsFields`] trait which when implemented on some type, describes how SCALE encoded bytes can be decoded
   into it with the help of an iterator of [`Field`]s and a type registry describing the shape of the encoded bytes. This is
   generally only implemented for tuples and structs, since we need a set of fields to map to the provided slices.

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -39,7 +39,7 @@ impl<'scale, 'resolver, R: TypeResolver> Variant<'scale, 'resolver, R> {
         // Does a variant exist with the index we're looking for?
         let mut variant = variants
             .find(|v| v.index == index)
-            .ok_or_else(|| DecodeError::VariantNotFound(index))?;
+            .ok_or(DecodeError::VariantNotFound(index))?;
 
         // Allow decoding of the fields:
         let fields = Composite::new(item_bytes, &mut variant.fields, types, false);

--- a/scale-decode/src/visitor/types/variant.rs
+++ b/scale-decode/src/visitor/types/variant.rs
@@ -37,9 +37,8 @@ impl<'scale, 'resolver, R: TypeResolver> Variant<'scale, 'resolver, R> {
         let item_bytes = &bytes[1..];
 
         // Does a variant exist with the index we're looking for?
-        let mut variant = variants
-            .find(|v| v.index == index)
-            .ok_or(DecodeError::VariantNotFound(index))?;
+        let mut variant =
+            variants.find(|v| v.index == index).ok_or(DecodeError::VariantNotFound(index))?;
 
         // Allow decoding of the fields:
         let fields = Composite::new(item_bytes, &mut variant.fields, types, false);


### PR DESCRIPTION
Now that we're generic over which `TypeResolver` to use, we don't need to depend on `scale-info`.

Also ended up adding `machete` and a check that the two README copies are identical to CI and fixing up some docs etc to not mention `scale-info`.