### PR TITLE
Actually remove scale-info from tree and prep for 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.11.1 - 2023-02-16
+
+- `scale-info` was still being pulled in via `scale-type-resolver`; this has now been fixed
+
 ## 0.11.0 - 2023-02-09
 
 Up until now, this crate depended heavily on `scale_info` to provide the type information that we used to drive our decoding of types. This release removes the explicit dependency on `scale-info`, and instead depends on `scale-type-resolver`, which offers a generic `TypeResolver` trait whose implementations are able to provide the information needed to decode types (see [this PR](https://github.com/paritytech/scale-decode/pull/45) for more details). So now, the traits and types in `scale-decode` have been made generic over which `TypeResolver` is used to help decode things. `scale-info::PortableRegistry` is one such implementation of `TypeResolver`, and so can continue to be used in a similar way to before.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,5 +17,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.11.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.11.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.11.1", path = "scale-decode" }
+scale-decode-derive = { version = "0.11.1", path = "scale-decode-derive" }

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -32,7 +32,7 @@ scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
-scale-type-resolver = "0.1"
+scale-type-resolver = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }
@@ -42,3 +42,4 @@ trybuild = "1.0.72"
 # Enable the scale-info feature for testing.
 scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"] }
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }
+scale-type-resolver = { version = "0.1.1", default-features = false, features = ["scale-info"] }

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -244,7 +244,7 @@ pub trait Visitor: Sized {
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::From, derive_more::Display)]
 pub enum DecodeError {
     /// Type ID was not found
-    #[display(fmt = "Could not find type with ID '{_0:?}'")]
+    #[display(fmt = "Could not find type with ID '{_0}'")]
     TypeIdNotFound(String),
     /// A low level error trying to resolve a type.
     #[display(fmt = "Failed to resolve type: {_0}")]


### PR DESCRIPTION
`scale-info` wa still being pulled in via `scale-type-resolver`. This has now been fixed.

Dependency tree with default (ie all) features enabled:

```
 % cargo tree -e no-dev  
scale-decode v0.11.1 (/Users/james/Work/scale-decode/scale-decode)
├── derive_more v0.99.17 (proc-macro)
│   ├── proc-macro2 v1.0.51
│   │   └── unicode-ident v1.0.6
│   ├── quote v1.0.23
│   │   └── proc-macro2 v1.0.51 (*)
│   └── syn v1.0.109
│       ├── proc-macro2 v1.0.51 (*)
│       ├── quote v1.0.23 (*)
│       └── unicode-ident v1.0.6
├── parity-scale-codec v3.4.0
│   ├── arrayvec v0.7.2
│   ├── byte-slice-cast v1.2.2
│   ├── impl-trait-for-tuples v0.2.2 (proc-macro)
│   │   ├── proc-macro2 v1.0.51 (*)
│   │   ├── quote v1.0.23 (*)
│   │   └── syn v1.0.109 (*)
│   └── parity-scale-codec-derive v3.1.4 (proc-macro)
│       ├── proc-macro-crate v1.3.1
│       │   ├── once_cell v1.17.1
│       │   └── toml_edit v0.19.4
│       │       ├── indexmap v1.9.2
│       │       │   └── hashbrown v0.12.3
│       │       │   [build-dependencies]
│       │       │   └── autocfg v1.1.0
│       │       ├── toml_datetime v0.6.1
│       │       └── winnow v0.3.3
│       ├── proc-macro2 v1.0.51 (*)
│       ├── quote v1.0.23 (*)
│       └── syn v1.0.109 (*)
├── primitive-types v0.12.1
│   ├── fixed-hash v0.8.0
│   │   └── static_assertions v1.1.0
│   └── uint v0.9.5
│       ├── byteorder v1.4.3
│       ├── crunchy v0.2.2
│       ├── hex v0.4.3
│       └── static_assertions v1.1.0
├── scale-bits v0.5.0
│   ├── parity-scale-codec v3.4.0 (*)
│   └── scale-type-resolver v0.1.1
├── scale-decode-derive v0.11.1 (proc-macro) (/Users/james/Work/scale-decode/scale-decode-derive)
│   ├── darling v0.14.3
│   │   ├── darling_core v0.14.3
│   │   │   ├── fnv v1.0.7
│   │   │   ├── ident_case v1.0.1
│   │   │   ├── proc-macro2 v1.0.51 (*)
│   │   │   ├── quote v1.0.23 (*)
│   │   │   ├── strsim v0.10.0
│   │   │   └── syn v1.0.109 (*)
│   │   └── darling_macro v0.14.3 (proc-macro)
│   │       ├── darling_core v0.14.3 (*)
│   │       ├── quote v1.0.23 (*)
│   │       └── syn v1.0.109 (*)
│   ├── proc-macro2 v1.0.51 (*)
│   ├── quote v1.0.23 (*)
│   └── syn v1.0.109 (*)
├── scale-type-resolver v0.1.1
└── smallvec v1.10.0
```