### PR TITLE
str: Ensure the input data is correct

### DIFF
--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -248,7 +248,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 // and let the visitor decide whether to use them or not.
                 let mut s = Str::new(data)?;
                 // Since we aren't decoding here, shift our bytes along to after the str:
-                *data = s.bytes_after();
+                *data = s.bytes_after()?;
                 visitor.visit_str(&mut s, type_id)
             }
             Primitive::U8 => {

--- a/scale-decode/src/visitor/types/str.rs
+++ b/scale-decode/src/visitor/types/str.rs
@@ -57,7 +57,7 @@ impl<'scale> Str<'scale> {
     pub fn as_str(&self) -> Result<&'scale str, DecodeError> {
         let start = self.compact_len;
         let end = start + self.len;
-        alloc::str::from_utf8(&self.bytes.get(start..end).ok_or(DecodeError::NotEnoughInput)?)
+        alloc::str::from_utf8(self.bytes.get(start..end).ok_or(DecodeError::NotEnoughInput)?)
             .map_err(DecodeError::InvalidStr)
     }
 }


### PR DESCRIPTION
Also change `Compact<u64>` to `Compact<u32>` to reflect the actual upper limit.