### PR TITLE
Return visitor errors over skip_decode errors if there are any

### DIFF
--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -107,7 +107,7 @@ macro_rules! skip_decoding_and_return {
             (_, Err(e)) => Err(e.into()),
             (Ok(v), _) => Ok(v),
         }
-    }}
+    }};
 }
 
 impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -123,10 +123,17 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let res = self.visitor.visit_composite(&mut items, self.type_id);
 
         // Skip over any bytes that the visitor chose not to decode:
-        items.skip_decoding()?;
-        *self.data = items.bytes_from_undecoded();
+        let skip_res = items.skip_decoding();
+        if skip_res.is_ok() {
+            *self.data = items.bytes_from_undecoded();
+        }
 
-        res
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match (res, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
     }
 
     fn visit_variant<Path, Fields, Var>(self, _path: Path, variants: Var) -> Self::Value
@@ -143,10 +150,17 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let res = self.visitor.visit_variant(&mut variant, self.type_id);
 
         // Skip over any bytes that the visitor chose not to decode:
-        variant.skip_decoding()?;
-        *self.data = variant.bytes_from_undecoded();
+        let skip_res = variant.skip_decoding();
+        if skip_res.is_ok() {
+            *self.data = variant.bytes_from_undecoded();
+        }
 
-        res
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match (res, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
     }
 
     fn visit_sequence<Path>(self, _path: Path, inner_type_id: Self::TypeId) -> Self::Value
@@ -161,10 +175,17 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let res = self.visitor.visit_sequence(&mut items, self.type_id);
 
         // Skip over any bytes that the visitor chose not to decode:
-        items.skip_decoding()?;
-        *self.data = items.bytes_from_undecoded();
+        let skip_res = items.skip_decoding();
+        if skip_res.is_ok() {
+            *self.data = items.bytes_from_undecoded();
+        }
 
-        res
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match (res, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
     }
 
     fn visit_array(self, inner_type_id: Self::TypeId, len: usize) -> Self::Value {
@@ -176,10 +197,17 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let res = self.visitor.visit_array(&mut arr, self.type_id);
 
         // Skip over any bytes that the visitor chose not to decode:
-        arr.skip_decoding()?;
-        *self.data = arr.bytes_from_undecoded();
+        let skip_res = arr.skip_decoding();
+        if skip_res.is_ok() {
+            *self.data = arr.bytes_from_undecoded();
+        }
 
-        res
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match (res, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
     }
 
     fn visit_tuple<TypeIds>(self, type_ids: TypeIds) -> Self::Value
@@ -196,10 +224,17 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let res = self.visitor.visit_tuple(&mut items, self.type_id);
 
         // Skip over any bytes that the visitor chose not to decode:
-        items.skip_decoding()?;
-        *self.data = items.bytes_from_undecoded();
+        let skip_res = items.skip_decoding();
+        if skip_res.is_ok() {
+            *self.data = items.bytes_from_undecoded();
+        }
 
-        res
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match (res, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
     }
 
     fn visit_primitive(self, primitive: Primitive) -> Self::Value {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -90,6 +90,26 @@ impl<'a, 'scale, 'resolver, V: Visitor> Decoder<'a, 'scale, 'resolver, V> {
     }
 }
 
+// Our types like Composite/Variant/Sequence/Array/Tuple all use the same
+// approach to skip over any bytes that the visitor didn't consume, so this
+// macro performs that logic.
+macro_rules! skip_decoding_and_return {
+    ($self:ident, $visit_result:ident, $visitor_ty:ident) => {{
+        // Skip over any bytes that the visitor chose not to decode:
+        let skip_res = $visitor_ty.skip_decoding();
+        if skip_res.is_ok() {
+            *$self.data = $visitor_ty.bytes_from_undecoded();
+        }
+
+        // Prioritize returning visitor errors over skip_decoding errors.
+        match ($visit_result, skip_res) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e.into()),
+            (Ok(v), _) => Ok(v),
+        }
+    }}
+}
+
 impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
     for Decoder<'temp, 'scale, 'resolver, V>
 {
@@ -122,18 +142,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let mut items = Composite::new(path, self.data, &mut fields, self.types, self.is_compact);
         let res = self.visitor.visit_composite(&mut items, self.type_id);
 
-        // Skip over any bytes that the visitor chose not to decode:
-        let skip_res = items.skip_decoding();
-        if skip_res.is_ok() {
-            *self.data = items.bytes_from_undecoded();
-        }
-
-        // Prioritize returning visitor errors over skip_decoding errors.
-        match (res, skip_res) {
-            (Err(e), _) => Err(e),
-            (_, Err(e)) => Err(e.into()),
-            (Ok(v), _) => Ok(v),
-        }
+        skip_decoding_and_return!(self, res, items)
     }
 
     fn visit_variant<Path, Fields, Var>(self, _path: Path, variants: Var) -> Self::Value
@@ -149,18 +158,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let mut variant = Variant::new(self.data, variants, self.types)?;
         let res = self.visitor.visit_variant(&mut variant, self.type_id);
 
-        // Skip over any bytes that the visitor chose not to decode:
-        let skip_res = variant.skip_decoding();
-        if skip_res.is_ok() {
-            *self.data = variant.bytes_from_undecoded();
-        }
-
-        // Prioritize returning visitor errors over skip_decoding errors.
-        match (res, skip_res) {
-            (Err(e), _) => Err(e),
-            (_, Err(e)) => Err(e.into()),
-            (Ok(v), _) => Ok(v),
-        }
+        skip_decoding_and_return!(self, res, variant)
     }
 
     fn visit_sequence<Path>(self, _path: Path, inner_type_id: Self::TypeId) -> Self::Value
@@ -174,18 +172,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let mut items = Sequence::new(self.data, inner_type_id, self.types)?;
         let res = self.visitor.visit_sequence(&mut items, self.type_id);
 
-        // Skip over any bytes that the visitor chose not to decode:
-        let skip_res = items.skip_decoding();
-        if skip_res.is_ok() {
-            *self.data = items.bytes_from_undecoded();
-        }
-
-        // Prioritize returning visitor errors over skip_decoding errors.
-        match (res, skip_res) {
-            (Err(e), _) => Err(e),
-            (_, Err(e)) => Err(e.into()),
-            (Ok(v), _) => Ok(v),
-        }
+        skip_decoding_and_return!(self, res, items)
     }
 
     fn visit_array(self, inner_type_id: Self::TypeId, len: usize) -> Self::Value {
@@ -196,18 +183,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let mut arr = Array::new(self.data, inner_type_id, len, self.types);
         let res = self.visitor.visit_array(&mut arr, self.type_id);
 
-        // Skip over any bytes that the visitor chose not to decode:
-        let skip_res = arr.skip_decoding();
-        if skip_res.is_ok() {
-            *self.data = arr.bytes_from_undecoded();
-        }
-
-        // Prioritize returning visitor errors over skip_decoding errors.
-        match (res, skip_res) {
-            (Err(e), _) => Err(e),
-            (_, Err(e)) => Err(e.into()),
-            (Ok(v), _) => Ok(v),
-        }
+        skip_decoding_and_return!(self, res, arr)
     }
 
     fn visit_tuple<TypeIds>(self, type_ids: TypeIds) -> Self::Value
@@ -223,18 +199,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
         let mut items = Tuple::new(self.data, &mut fields, self.types, self.is_compact);
         let res = self.visitor.visit_tuple(&mut items, self.type_id);
 
-        // Skip over any bytes that the visitor chose not to decode:
-        let skip_res = items.skip_decoding();
-        if skip_res.is_ok() {
-            *self.data = items.bytes_from_undecoded();
-        }
-
-        // Prioritize returning visitor errors over skip_decoding errors.
-        match (res, skip_res) {
-            (Err(e), _) => Err(e),
-            (_, Err(e)) => Err(e.into()),
-            (Ok(v), _) => Ok(v),
-        }
+        skip_decoding_and_return!(self, res, items)
     }
 
     fn visit_primitive(self, primitive: Primitive) -> Self::Value {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -955,39 +955,58 @@ mod test {
         );
     }
 
-    #[test]
-    fn decoding_returns_visitor_error_first() {
-        fn visitor_err() -> DecodeError {
-            DecodeError::TypeResolvingError("Whoops".to_string())
-        }
+    // We want to make sure that if the visitor returns an error, then that error is propagated
+    // up to the user. with some types (Sequence/Composite/Tuple/Array/Variant), we skip over
+    // undecoded items after the visitor runs, and want to ensure that any error skipping over
+    // things doesn't mask any visitor error.
+    macro_rules! decoding_returns_error_first {
+        ($name:ident $expr:expr) => {
+            #[test]
+            fn $name() {
+                fn visitor_err() -> DecodeError {
+                    DecodeError::TypeResolvingError("Whoops".to_string())
+                }
 
-        #[derive(codec::Encode)]
-        struct HasBadTypeInfo;
-        impl scale_info::TypeInfo for HasBadTypeInfo {
-            type Identity = Self;
-            fn type_info() -> scale_info::Type {
-                // The actual struct is zero bytes but the type info says it is 1 byte,
-                // so using type info to decode it will lead to failures.
-                scale_info::meta_type::<u8>().type_info()
+                #[derive(codec::Encode)]
+                struct HasBadTypeInfo;
+                impl scale_info::TypeInfo for HasBadTypeInfo {
+                    type Identity = Self;
+                    fn type_info() -> scale_info::Type {
+                        // The actual struct is zero bytes but the type info says it is 1 byte,
+                        // so using type info to decode it will lead to failures.
+                        scale_info::meta_type::<u8>().type_info()
+                    }
+                }
+
+                struct VisitorImpl;
+                impl Visitor for VisitorImpl {
+                    type Value<'scale, 'resolver> = ();
+                    type Error = DecodeError;
+                    type TypeResolver = PortableRegistry;
+
+                    fn visit_unexpected<'scale, 'resolver>(
+                        self,
+                        _unexpected: Unexpected,
+                    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
+                        // Our visitor just returns a specific error, so we can check that
+                        // we get it back when trying to decode.
+                        Err(visitor_err())
+                    }
+                }
+
+                fn assert_visitor_err<E: codec::Encode + scale_info::TypeInfo + 'static>(input: E) {
+                    let input_encoded = input.encode();
+                    let (ty_id, types) = make_type::<E>();
+                    let err = decode_with_visitor(&mut &*input_encoded, ty_id, &types, VisitorImpl).unwrap_err();
+                    assert_eq!(err, visitor_err());
+                }
+
+                assert_visitor_err($expr);
             }
         }
+    }
 
-        struct VisitorImpl;
-        impl Visitor for VisitorImpl {
-            type Value<'scale, 'resolver> = ();
-            type Error = DecodeError;
-            type TypeResolver = PortableRegistry;
-
-            fn visit_unexpected<'scale, 'resolver>(
-                self,
-                _unexpected: Unexpected,
-            ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
-                // Our visitor just returns a specific error, so we can check that
-                // we get it back when trying to decode.
-                Err(visitor_err())
-            }
-        }
-
+    decoding_returns_error_first!(decode_composite_returns_error_first {
         #[derive(codec::Encode, scale_info::TypeInfo)]
         struct SomeComposite {
             a: bool,
@@ -995,33 +1014,29 @@ mod test {
             c: Vec<u8>
         }
 
+        SomeComposite { a: true, b: HasBadTypeInfo, c: vec![1,2,3] }
+    });
+
+    decoding_returns_error_first!(decode_variant_returns_error_first {
         #[derive(codec::Encode, scale_info::TypeInfo)]
         enum SomeVariant {
             Foo(u32, HasBadTypeInfo, String)
         }
 
-        fn assert_visitor_err<E: codec::Encode + scale_info::TypeInfo + 'static>(input: E) {
-            let input_encoded = input.encode();
-            let (ty_id, types) = make_type::<E>();
-            let err = decode_with_visitor(&mut &*input_encoded, ty_id, &types, VisitorImpl).unwrap_err();
-            assert_eq!(err, visitor_err());
-        }
+        SomeVariant::Foo(32, HasBadTypeInfo, "hi".to_owned())
+    });
 
-        // Test composites:
-        assert_visitor_err(SomeComposite { a: true, b: HasBadTypeInfo, c: vec![1,2,3] });
+    decoding_returns_error_first!(decode_array_returns_error_first {
+        [HasBadTypeInfo, HasBadTypeInfo]
+    });
 
-        // Test arrays:
-        assert_visitor_err([HasBadTypeInfo, HasBadTypeInfo]);
+    decoding_returns_error_first!(decode_sequence_returns_error_first {
+        vec![HasBadTypeInfo, HasBadTypeInfo]
+    });
 
-        // Test sequences:
-        assert_visitor_err(vec![HasBadTypeInfo, HasBadTypeInfo]);
-
-        // Test tuples
-        assert_visitor_err((32u64, HasBadTypeInfo, true));
-
-        // Test variants
-        assert_visitor_err(SomeVariant::Foo(32, HasBadTypeInfo, "hi".to_owned()));
-    }
+    decoding_returns_error_first!(decode_tuple_returns_error_first {
+        (32u64, HasBadTypeInfo, true)
+    });
 
     #[test]
     fn zero_copy_string_decoding() {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -997,13 +997,14 @@ mod test {
                 fn assert_visitor_err<E: codec::Encode + scale_info::TypeInfo + 'static>(input: E) {
                     let input_encoded = input.encode();
                     let (ty_id, types) = make_type::<E>();
-                    let err = decode_with_visitor(&mut &*input_encoded, ty_id, &types, VisitorImpl).unwrap_err();
+                    let err = decode_with_visitor(&mut &*input_encoded, ty_id, &types, VisitorImpl)
+                        .unwrap_err();
                     assert_eq!(err, visitor_err());
                 }
 
                 assert_visitor_err($expr);
             }
-        }
+        };
     }
 
     decoding_returns_error_first!(decode_composite_returns_error_first {

--- a/scale-decode/src/visitor/mod.rs
+++ b/scale-decode/src/visitor/mod.rs
@@ -959,6 +959,9 @@ mod test {
     // up to the user. with some types (Sequence/Composite/Tuple/Array/Variant), we skip over
     // undecoded items after the visitor runs, and want to ensure that any error skipping over
     // things doesn't mask any visitor error.
+    //
+    // These tests all fail prior to https://github.com/paritytech/scale-decode/pull/58 and pass
+    // after it.
     macro_rules! decoding_returns_error_first {
         ($name:ident $expr:expr) => {
             #[test]


### PR DESCRIPTION
Before this, if we hit an error when skipping over any remaining composite/variant/tuple/sequence items, we'd return that error, even if the visitor which we called returned an error of its own. This would obscure more meaningful errors behind vague skip_decode ones.

Now we prioritize returning visitor errors if there are any, to get somehting more useful back! 