### PR TITLE
Prep for 0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## 0.13.0 - 2023-05-15
+## 0.13.1 - 2024-06-07
+
+Useful visitor errors can be hidden in some cases when a `skip_decoding` error is also emitted. This patch release fixes that.
+
+## Fixed
+
+- Don't hide visitor error when a skip_decode error is also emitted ([#58](https://github.com/paritytech/scale-decode/pull/58))
+
+## 0.13.0 - 2024-05-15
 
 This minor release avoids a couple of panics in the case of invalid bytes being interpreted as BitVecs or strings.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,5 +17,5 @@ keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-decode = { version = "0.13.0", path = "scale-decode" }
-scale-decode-derive = { version = "0.13.0", path = "scale-decode-derive" }
+scale-decode = { version = "0.13.1", path = "scale-decode" }
+scale-decode-derive = { version = "0.13.1", path = "scale-decode-derive" }


### PR DESCRIPTION
## 0.13.1 - 2024-06-07

Useful visitor errors can be hidden in some cases when a `skip_decoding` error is also emitted. This patch release fixes that.

## Fixed

- Don't hide visitor error when a skip_decode error is also emitted ([#58](https://github.com/paritytech/scale-decode/pull/58))