### PR TITLE
update some deps to use syn2

### DIFF
--- a/scale-decode-derive/Cargo.toml
+++ b/scale-decode-derive/Cargo.toml
@@ -17,7 +17,7 @@ include.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-darling = "0.14.2"
+darling = "0.20.9"

--- a/scale-decode-derive/src/lib.rs
+++ b/scale-decode-derive/src/lib.rs
@@ -13,6 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// https://github.com/rust-lang/rust-clippy/issues/12643.
+// related to `darling::default` attribute expansion
+#![allow(clippy::manual_unwrap_or_default)]
+
 extern crate alloc;
 
 use alloc::string::ToString;
@@ -539,11 +543,11 @@ impl TopLevelAttrs {
 
         // look at each top level attr. parse any for decode_as_type.
         for attr in attrs {
-            if !attr.path.is_ident(ATTR_NAME) {
+            if !attr.path().is_ident(ATTR_NAME) {
                 continue;
             }
-            let meta = attr.parse_meta()?;
-            let parsed_attrs = TopLevelAttrsInner::from_meta(&meta)?;
+            let meta = &attr.meta;
+            let parsed_attrs = TopLevelAttrsInner::from_meta(meta)?;
 
             res.trait_bounds = parsed_attrs.trait_bounds;
             if let Some(crate_path) = parsed_attrs.crate_path {


### PR DESCRIPTION
### Description 
Now the only deps that pull in `syn@1` are parity-scale-codec and scale-info