### PR TITLE
use `core::error::Error` and remove std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/paritytech/scale-decode"
 homepage = "https://www.parity.io/"
 keywords = ["parity", "scale", "decoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 scale-decode = { version = "0.14.0", path = "scale-decode" }

--- a/scale-decode-derive/Cargo.toml
+++ b/scale-decode-derive/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 include.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/scale-decode/Cargo.toml
+++ b/scale-decode/Cargo.toml
@@ -12,12 +12,10 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 include.workspace = true
+rust-version.workspace = true
 
 [features]
-default = ["std", "derive", "primitive-types"]
-
-# Activates std feature.
-std = []
+default = ["derive", "primitive-types"]
 
 # Impls for primitive-types.
 primitive-types = ["dep:primitive-types"]
@@ -31,8 +29,8 @@ scale-bits = { version = "0.6.0", default-features = false }
 scale-decode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.13.1", optional = true, default-features = false }
 smallvec = "1.10.0"
-derive_more = { version = "1.0.0", default-features = false, features = ["from", "display"] }
 scale-type-resolver = { version = "0.2.0", default-features = false }
+thiserror = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec", "derive"] }

--- a/scale-decode/src/error/mod.rs
+++ b/scale-decode/src/error/mod.rs
@@ -29,8 +29,7 @@ pub struct Error {
     kind: ErrorKind,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl Error {
     /// Construct a new error given an error kind.
@@ -38,24 +37,22 @@ impl Error {
         Error { context: Context::new(), kind }
     }
     /// Construct a new, custom error.
-    pub fn custom(error: impl CustomError) -> Error {
+    pub fn custom(error: impl core::error::Error + Send + Sync + 'static) -> Error {
         Error::new(ErrorKind::Custom(Box::new(error)))
     }
     /// Construct a custom error from a static string.
     pub fn custom_str(error: &'static str) -> Error {
-        #[derive(derive_more::Display, Debug)]
+        #[derive(Debug, thiserror::Error)]
+        #[error("{0}")]
         pub struct StrError(pub &'static str);
-        #[cfg(feature = "std")]
-        impl std::error::Error for StrError {}
 
         Error::new(ErrorKind::Custom(Box::new(StrError(error))))
     }
     /// Construct a custom error from an owned string.
     pub fn custom_string(error: String) -> Error {
-        #[derive(derive_more::Display, Debug)]
+        #[derive(Debug, thiserror::Error)]
+        #[error("{0}")]
         pub struct StringError(String);
-        #[cfg(feature = "std")]
-        impl std::error::Error for StringError {}
 
         Error::new(ErrorKind::Custom(Box::new(StringError(error))))
     }
@@ -111,21 +108,20 @@ impl From<codec::Error> for Error {
 }
 
 /// The underlying nature of the error.
-#[derive(Debug, derive_more::From, derive_more::Display)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
     /// Something went wrong decoding the bytes based on the type
     /// and type registry provided.
-    #[from]
-    #[display("Error decoding bytes given the type ID and registry provided: {_0}")]
-    VisitorDecodeError(DecodeError),
+    #[error("Error decoding bytes given the type ID and registry provided: {_0}")]
+    VisitorDecodeError(#[from] DecodeError),
     /// We cannot decode the number seen into the target type; it's out of range.
-    #[display("Number {value} is out of range")]
+    #[error("Number {value} is out of range")]
     NumberOutOfRange {
         /// A string representation of the numeric value that was out of range.
         value: String,
     },
     /// We cannot find the variant we're trying to decode from in the target type.
-    #[display("Cannot find variant {got}; expects one of {expected:?}")]
+    #[error("Cannot find variant {got}; expects one of {expected:?}")]
     CannotFindVariant {
         /// The variant that we are given back from the encoded bytes.
         got: String,
@@ -133,9 +129,7 @@ pub enum ErrorKind {
         expected: Vec<&'static str>,
     },
     /// The types line up, but the expected length of the target type is different from the length of the input value.
-    #[display(
-        "Cannot decode from type; expected length {expected_len} but got length {actual_len}"
-    )]
+    #[error("Cannot decode from type; expected length {expected_len} but got length {actual_len}")]
     WrongLength {
         /// Length of the type we are trying to decode from
         actual_len: usize,
@@ -143,44 +137,12 @@ pub enum ErrorKind {
         expected_len: usize,
     },
     /// Cannot find a field that we need to decode to our target type
-    #[display("Field {name} does not exist in our encoded data")]
+    #[error("Field {name} does not exist in our encoded data")]
     CannotFindField {
         /// Name of the field which was not provided.
         name: String,
     },
     /// A custom error.
-    #[from]
-    #[display("Custom error: {_0}")]
-    Custom(Box<dyn CustomError>),
-}
-
-/// Anything implementing this trait can be used in [`ErrorKind::Custom`].
-#[cfg(feature = "std")]
-pub trait CustomError: std::error::Error + Send + Sync + 'static {}
-#[cfg(feature = "std")]
-impl<T: std::error::Error + Send + Sync + 'static> CustomError for T {}
-
-/// Anything implementing this trait can be used in [`ErrorKind::Custom`].
-#[cfg(not(feature = "std"))]
-pub trait CustomError: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static {}
-#[cfg(not(feature = "std"))]
-impl<T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[derive(Debug, derive_more::Display)]
-    enum MyError {
-        Foo,
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for MyError {}
-
-    #[test]
-    fn custom_error() {
-        // Just a compile-time check that we can ergonomically provide an arbitrary custom error:
-        Error::custom(MyError::Foo);
-    }
+    #[error("Custom error: {0}")]
+    Custom(Box<dyn core::error::Error + Send + Sync + 'static>),
 }

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 /*!
 `parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those
 types. This crate builds on this, and allows bytes to be decoded into types based on type information, rather than the shape

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -315,6 +315,6 @@ pub trait IntoVisitor {
 /// - `#[decode_as_type(skip)]` (or `#[codec(skip)]`):
 ///   Any fields annotated with this will be skipped when attempting to decode into the
 ///   type, and instead will be populated with their default value (and therefore must
-///   implement [`std::default::Default`]).
+///   implement [`core::default::Default`]).
 #[cfg(feature = "derive")]
 pub use scale_decode_derive::DecodeAsType;

--- a/scale-decode/src/lib.rs
+++ b/scale-decode/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![no_std]
+
 /*!
 `parity-scale-codec` provides a `Decode` trait which allows bytes to be scale decoded into types based on the shape of those
 types. This crate builds on this, and allows bytes to be decoded into types based on type information, rather than the shape

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -257,7 +257,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u8::decode(data)
                 }
-                .map_err(|e| e.into())?;
+                .map_err(Into::into)?;
                 visitor.visit_u8(n, type_id)
             }
             Primitive::U16 => {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -293,7 +293,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u128::decode(data)
                 }
-                .map_err(|e| e.into())?;
+                .map_err(Into::into)?;
                 visitor.visit_u128(n, type_id)
             }
             Primitive::U256 => {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -275,7 +275,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u32::decode(data)
                 }
-                .map_err(|e| e.into())?;
+                .map_err(Into::into)?;
                 visitor.visit_u32(n, type_id)
             }
             Primitive::U64 => {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -257,7 +257,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u8::decode(data)
                 }
-                .map_err(Into::into)?;
+                .map_err(|e| e.into())?;
                 visitor.visit_u8(n, type_id)
             }
             Primitive::U16 => {
@@ -266,7 +266,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u16::decode(data)
                 }
-                .map_err(Into::into)?;
+                .map_err(|e| e.into())?;
                 visitor.visit_u16(n, type_id)
             }
             Primitive::U32 => {
@@ -275,7 +275,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u32::decode(data)
                 }
-                .map_err(Into::into)?;
+                .map_err(|e| e.into())?;
                 visitor.visit_u32(n, type_id)
             }
             Primitive::U64 => {
@@ -284,7 +284,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u64::decode(data)
                 }
-                .map_err(Into::into)?;
+                .map_err(|e| e.into())?;
                 visitor.visit_u64(n, type_id)
             }
             Primitive::U128 => {
@@ -293,7 +293,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u128::decode(data)
                 }
-                .map_err(Into::into)?;
+                .map_err(|e| e.into())?;
                 visitor.visit_u128(n, type_id)
             }
             Primitive::U256 => {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -266,7 +266,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u16::decode(data)
                 }
-                .map_err(|e| e.into())?;
+                .map_err(Into::into)?;
                 visitor.visit_u16(n, type_id)
             }
             Primitive::U32 => {

--- a/scale-decode/src/visitor/decode.rs
+++ b/scale-decode/src/visitor/decode.rs
@@ -284,7 +284,7 @@ impl<'temp, 'scale, 'resolver, V: Visitor> ResolvedTypeVisitor<'resolver>
                 } else {
                     u64::decode(data)
                 }
-                .map_err(|e| e.into())?;
+                .map_err(Into::into)?;
                 visitor.visit_u64(n, type_id)
             }
             Primitive::U128 => {


### PR DESCRIPTION
This PR changes:

1. Remove std feature and replace it with `core::error::Error`
2. Replace derive_more with thiserror (thiserror uses internally core::error::Error when rustc >= 1.81 is used)
3. Add MSRV 1.81 