### PR TITLE
Prep 0.16.2 release: impl DecodeItemIterator on mut T's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.2 - 2025-11-21
+
+- Implement `DecodeItemIterator` on `&mut T`s as well, so that we can use it more easily from visitors.
+
 ## 0.16.1 - 2025-11-19
 
 - Expose path information in sequences and variants, too, where possible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/scale-decode/src/visitor/types/array.rs
+++ b/scale-decode/src/visitor/types/array.rs
@@ -157,3 +157,13 @@ impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'sca
         self.decode_item(visitor)
     }
 }
+impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'resolver, R>
+    for &mut Array<'scale, 'resolver, R>
+{
+    fn decode_item<V: Visitor<TypeResolver = R>>(
+        &mut self,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'resolver>, V::Error>> {
+        (*self).decode_item(visitor)
+    }
+}

--- a/scale-decode/src/visitor/types/composite.rs
+++ b/scale-decode/src/visitor/types/composite.rs
@@ -225,3 +225,13 @@ impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'sca
         self.decode_item(visitor)
     }
 }
+impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'resolver, R>
+    for &mut Composite<'scale, 'resolver, R>
+{
+    fn decode_item<'a, V: Visitor<TypeResolver = R>>(
+        &mut self,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'resolver>, V::Error>> {
+        (*self).decode_item(visitor)
+    }
+}

--- a/scale-decode/src/visitor/types/sequence.rs
+++ b/scale-decode/src/visitor/types/sequence.rs
@@ -140,3 +140,13 @@ impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'sca
         self.decode_item(visitor)
     }
 }
+impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'resolver, R>
+    for &mut Sequence<'scale, 'resolver, R>
+{
+    fn decode_item<V: Visitor<TypeResolver = R>>(
+        &mut self,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'resolver>, V::Error>> {
+        (*self).decode_item(visitor)
+    }
+}

--- a/scale-decode/src/visitor/types/tuple.rs
+++ b/scale-decode/src/visitor/types/tuple.rs
@@ -171,3 +171,13 @@ impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'sca
         self.decode_item(visitor)
     }
 }
+impl<'scale, 'resolver, R: TypeResolver> crate::visitor::DecodeItemIterator<'scale, 'resolver, R>
+    for &mut Tuple<'scale, 'resolver, R>
+{
+    fn decode_item<'a, V: Visitor<TypeResolver = R>>(
+        &mut self,
+        visitor: V,
+    ) -> Option<Result<V::Value<'scale, 'resolver>, V::Error>> {
+        (*self).decode_item(visitor)
+    }
+}


### PR DESCRIPTION
- Implement `DecodeItemIterator` on `&mut T`s as well, so that we can use it more easily from visitors.